### PR TITLE
検索画面へのリンクを用意

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mantine/core": "^7.10.0",
         "@mantine/form": "^7.10.1",
         "@mantine/hooks": "^7.10.0",
+        "@tabler/icons-react": "^3.5.0",
         "axios": "^1.7.2",
         "next": "14.2.3",
         "next-auth": "^5.0.0-beta.18",
@@ -1829,6 +1830,32 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.5.0.tgz",
+      "integrity": "sha512-I53dC3ZSHQ2MZFGvDYJelfXm91L2bTTixS4w5jTAulLhHbCZso5Bih4Rk/NYZxlngLQMKHvEYwZQ+6w/WluKiA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.5.0.tgz",
+      "integrity": "sha512-bn05XKZV3ZfOv5Jr1FCTmVPOQGBVJoA4NefrnR919rqg6WGXAa08NovONHJGSuMxXUMV3b9Cni85diIW/E9yuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tabler/icons": "3.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mantine/core": "^7.10.0",
     "@mantine/form": "^7.10.1",
     "@mantine/hooks": "^7.10.0",
+    "@tabler/icons-react": "^3.5.0",
     "axios": "^1.7.2",
     "next": "14.2.3",
     "next-auth": "^5.0.0-beta.18",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <MantineProvider>{children}</MantineProvider>
+        <main className="flex min-h-screen flex-col items-center justify-between p-24">
+          <MantineProvider>{children}</MantineProvider>
+        </main>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,11 @@
 import Login from '@/components/Login';
-import SearchHome from '@/components/search/SearchHome';
+import SearchBooksButton from '@/components/button/SearchBooksButton';
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <SearchHome />
+    <div>
+      <SearchBooksButton />
       <Login />
-    </main>
+    </div>
   );
 }

--- a/src/app/search_books/page.tsx
+++ b/src/app/search_books/page.tsx
@@ -1,0 +1,5 @@
+import SearchHome from '@/components/search/SearchHome';
+
+export default function Page() {
+  return <SearchHome />;
+}

--- a/src/components/button/SearchBooksButton.tsx
+++ b/src/components/button/SearchBooksButton.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Button } from '@mantine/core';
+import { IconArrowRight } from '@tabler/icons-react';
+import { useRouter } from 'next/navigation';
+
+const SearchBooksButton = () => {
+  const router = useRouter();
+  return (
+    <Button
+      variant="light"
+      rightSection={<IconArrowRight size={14} />}
+      onClick={() => router.push('/search_books')}
+    >
+      本を追加
+    </Button>
+  );
+};
+
+export default SearchBooksButton;


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/48

## description
最初ルート画面に表示してしまっていたので、以下を実装。

検索画面へのリンクとして`SearchBooksButton.tsx`を追加し、ルート画面に表示した。クライアントコンポーネントとしてMantineの`Button`と`useRouter`で`/search_books`へ遷移する。

遷移先には`src/app/search_books/page.tsx`を追加し、`SearchHome`を表示する。
