### PR TITLE
本登録時のモーダル追加

### DIFF
--- a/src/__mocks__/next-auth/react.js
+++ b/src/__mocks__/next-auth/react.js
@@ -1,0 +1,17 @@
+import { jest } from '@jest/globals';
+
+const mockUseSession = jest.fn().mockReturnValue({
+  data: {
+    user: {
+      name: 'Test User',
+      email: 'test@example.com',
+      image: 'https://example.com/test.png',
+    },
+    expires: '2024-06-30T00:00:00.000Z',
+  },
+  status: 'authenticated',
+});
+
+const SessionProvider = ({ children }) => children;
+
+export { mockUseSession as useSession, SessionProvider };

--- a/src/__mocks__/next/navigation.js
+++ b/src/__mocks__/next/navigation.js
@@ -1,0 +1,7 @@
+import { jest } from '@jest/globals';
+
+const mockUseRouter = jest.fn().mockReturnValue({
+  push: jest.fn(),
+});
+
+export { mockUseRouter as useRouter };

--- a/src/__tests__/feature/modal/AddBookConfirmModal.test.tsx
+++ b/src/__tests__/feature/modal/AddBookConfirmModal.test.tsx
@@ -1,0 +1,48 @@
+import { screen } from '@testing-library/react';
+import { render } from '@/test-utils/render';
+import Results from '@/components/search/Results';
+import AddBookConfirmContent from '@/components/modal/AddBookConfirmContent';
+import axios from 'axios';
+import userEvent from '@testing-library/user-event';
+import { useRouter } from 'next/navigation';
+
+const user = userEvent.setup();
+
+jest.mock('axios');
+jest.mock('next-auth/react');
+jest.mock('next/navigation');
+
+const mockBook = {
+  id: 1,
+  title: 'テストの書籍',
+  author: 'テスト書籍の著者',
+  imageUrl: 'https://thumnailtest1.jpg',
+};
+
+const mockedAxiosGet = axios.get as jest.Mock;
+mockedAxiosGet.mockResolvedValue([mockBook]);
+
+const mockedAxiosPost = axios.post as jest.Mock;
+mockedAxiosPost.mockResolvedValue({ status: 200 });
+
+describe('AddBookConfirmModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show modal content', async () => {
+    render(<Results results={[mockBook]} />);
+    const value = '本棚に追加';
+    await user.click(screen.getByText(value));
+    const bookTitle =
+      await screen.findByText('テストの書籍を本棚に追加しますか？');
+    expect(bookTitle).toBeInTheDocument();
+  });
+
+  it('should call router.push on book addition', async () => {
+    render(<AddBookConfirmContent book={mockBook} />);
+    const value = '追加';
+    await user.click(screen.getByText(value));
+    expect(useRouter().push).toHaveBeenCalledWith('/');
+  });
+});

--- a/src/components/button/AddBookConfirmButton.tsx
+++ b/src/components/button/AddBookConfirmButton.tsx
@@ -1,6 +1,7 @@
 import { useDisclosure } from '@mantine/hooks';
 import { Modal, Button } from '@mantine/core';
 import AddBookConfirmContent from '../modal/AddBookConfirmContent';
+import { SessionProvider } from 'next-auth/react';
 
 type Book = {
   id: number;
@@ -17,12 +18,12 @@ export default function AddBookConfirmButton({ book }: BookProps) {
   const [opened, { open, close }] = useDisclosure(false);
 
   return (
-    <>
+    <SessionProvider>
       <Modal opened={opened} onClose={close} title="" centered>
         <AddBookConfirmContent book={book} />
       </Modal>
 
       <Button onClick={open}>本棚に追加</Button>
-    </>
+    </SessionProvider>
   );
 }

--- a/src/components/button/AddBookConfirmButton.tsx
+++ b/src/components/button/AddBookConfirmButton.tsx
@@ -11,10 +11,10 @@ type Book = {
 };
 
 type BookProps = {
-  book: Book
-}
+  book: Book;
+};
 
-export default function AddBookConfirmButton({ book }: BookProps) {
+const AddBookConfirmButton = ({ book }: BookProps) => {
   const [opened, { open, close }] = useDisclosure(false);
 
   return (
@@ -26,4 +26,6 @@ export default function AddBookConfirmButton({ book }: BookProps) {
       <Button onClick={open}>本棚に追加</Button>
     </SessionProvider>
   );
-}
+};
+
+export default AddBookConfirmButton;

--- a/src/components/button/AddBookConfirmButton.tsx
+++ b/src/components/button/AddBookConfirmButton.tsx
@@ -1,0 +1,28 @@
+import { useDisclosure } from '@mantine/hooks';
+import { Modal, Button } from '@mantine/core';
+import AddBookConfirmContent from '../modal/AddBookConfirmContent';
+
+type Book = {
+  id: number;
+  title: string;
+  author: string;
+  imageUrl: string;
+};
+
+type BookProps = {
+  book: Book
+}
+
+export default function AddBookConfirmButton({ book }: BookProps) {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  return (
+    <>
+      <Modal opened={opened} onClose={close} title="" centered>
+        <AddBookConfirmContent book={book} />
+      </Modal>
+
+      <Button onClick={open}>Open centered Modal</Button>
+    </>
+  );
+}

--- a/src/components/button/AddBookConfirmButton.tsx
+++ b/src/components/button/AddBookConfirmButton.tsx
@@ -22,7 +22,7 @@ export default function AddBookConfirmButton({ book }: BookProps) {
         <AddBookConfirmContent book={book} />
       </Modal>
 
-      <Button onClick={open}>Open centered Modal</Button>
+      <Button onClick={open}>本棚に追加</Button>
     </>
   );
 }

--- a/src/components/modal/AddBookConfirmContent.tsx
+++ b/src/components/modal/AddBookConfirmContent.tsx
@@ -1,0 +1,35 @@
+import { Card, Image, Text, Button, Group } from '@mantine/core';
+
+type Book = {
+  id: number;
+  title: string;
+  author: string;
+  imageUrl: string;
+};
+
+type BookProps = {
+  book: Book
+}
+
+const AddBookConfirmContent = ({book}: BookProps) => {
+  return (
+    <Card shadow="sm" padding="sm" radius="md" withBorder>
+        <Image
+          src={book.imageUrl}
+          w={100}
+          h={100}
+          alt="book"
+        />
+
+      <Group justify="space-between" mt="md" mb="xs">
+        <Text fw={500}>{book.title}を本棚に追加しますか？</Text>
+      </Group>
+
+      <Button color="blue" mt="md" radius="md">
+        追加
+      </Button>
+    </Card>
+  );
+}
+
+export default AddBookConfirmContent

--- a/src/components/modal/AddBookConfirmContent.tsx
+++ b/src/components/modal/AddBookConfirmContent.tsx
@@ -1,4 +1,6 @@
 import { Card, Image, Text, Button, Group } from '@mantine/core';
+import axios from 'axios';
+import { useSession } from 'next-auth/react';
 
 type Book = {
   id: number;
@@ -8,28 +10,47 @@ type Book = {
 };
 
 type BookProps = {
-  book: Book
-}
+  book: Book;
+};
 
-const AddBookConfirmContent = ({book}: BookProps) => {
+const AddBookConfirmContent = ({ book }: BookProps) => {
+  const { data: session } = useSession();
+
+  const handleSubmit = async () => {
+    const title = book.title;
+    const author = book.author;
+    const cover_image_url = book.imageUrl;
+    const email = session?.user?.email;
+    try {
+      const res = await axios.post('http://localhost:3001/api/books', {
+        title,
+        author,
+        cover_image_url,
+        email,
+      });
+      if (res.status === 200) {
+        return true;
+      } else {
+        return false;
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   return (
     <Card shadow="sm" padding="sm" radius="md" withBorder>
-        <Image
-          src={book.imageUrl}
-          w={100}
-          h={100}
-          alt="book"
-        />
+      <Image src={book.imageUrl} w={100} h={100} alt="book" />
 
       <Group justify="space-between" mt="md" mb="xs">
         <Text fw={500}>{book.title}を本棚に追加しますか？</Text>
       </Group>
 
-      <Button color="blue" mt="md" radius="md">
+      <Button color="blue" mt="md" radius="md" onClick={handleSubmit}>
         追加
       </Button>
     </Card>
   );
-}
+};
 
-export default AddBookConfirmContent
+export default AddBookConfirmContent;

--- a/src/components/modal/AddBookConfirmContent.tsx
+++ b/src/components/modal/AddBookConfirmContent.tsx
@@ -1,6 +1,7 @@
 import { Card, Image, Text, Button, Group } from '@mantine/core';
 import axios from 'axios';
 import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 
 type Book = {
   id: number;
@@ -15,6 +16,7 @@ type BookProps = {
 
 const AddBookConfirmContent = ({ book }: BookProps) => {
   const { data: session } = useSession();
+  const router = useRouter();
 
   const handleSubmit = async () => {
     const title = book.title;
@@ -29,7 +31,7 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
         email,
       });
       if (res.status === 200) {
-        return true;
+        router.push('/');
       } else {
         return false;
       }

--- a/src/components/search/Results.tsx
+++ b/src/components/search/Results.tsx
@@ -1,4 +1,5 @@
 import { Image } from '@mantine/core';
+import AddBookConfirmButton from '../button/AddBookConfirmButton';
 
 type Result = {
   id: number;
@@ -26,6 +27,7 @@ const Results = ({ results }: ResultProps) => {
               src={result.imageUrl}
               alt={result.title}
             />
+            <AddBookConfirmButton book={result}/>
           </div>
         ))
       ) : (

--- a/src/components/search/Results.tsx
+++ b/src/components/search/Results.tsx
@@ -27,7 +27,7 @@ const Results = ({ results }: ResultProps) => {
               src={result.imageUrl}
               alt={result.title}
             />
-            <AddBookConfirmButton book={result}/>
+            <AddBookConfirmButton book={result} />
           </div>
         ))
       ) : (

--- a/src/components/search/SearchForm.tsx
+++ b/src/components/search/SearchForm.tsx
@@ -58,10 +58,10 @@ const SearchForm = ({ onResults }: SearchFormProps) => {
     },
   });
 
-  const handleSubmit = async (values: { searchWord: string }) => {
+  const handleSubmit = async (value: { searchWord: string }) => {
     try {
       const res = await axios.get(
-        `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?applicationId=1063966721330772407&title=${values.searchWord}`,
+        `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?applicationId=1063966721330772407&title=${value.searchWord}`,
       );
       const books = res.data.Items.map((element: ItemProps, index: number) => ({
         id: index + 1,

--- a/src/components/search/SearchForm.tsx
+++ b/src/components/search/SearchForm.tsx
@@ -58,10 +58,10 @@ const SearchForm = ({ onResults }: SearchFormProps) => {
     },
   });
 
-  const handleSubmit = async (value: { searchWord: string }) => {
+  const handleSubmit = async (values: { searchWord: string }) => {
     try {
       const res = await axios.get(
-        `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?applicationId=1063966721330772407&title=${value.searchWord}`,
+        `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?applicationId=1063966721330772407&title=${values.searchWord}`,
       );
       const books = res.data.Items.map((element: ItemProps, index: number) => ({
         id: index + 1,


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/45

## description
本登録のモーダル、Railsにデータを送り登録成功したらルート画面に遷移する処理を追加。

`AddBookConfirmButton.tsx`でMantineの`useDisclosure`と`Modal`を使い確認モーダルを開閉し、中身は`AddBookConfirmContent.tsx`に置いた。`AddBookConfirmContent.tsx`から`POST /api/books`にtitle、author、cover_image_url、emailを送信し、成功時にルート画面へ遷移する。セッションはクライアントコンポーネントのため`useSession`を使用し、`SessionProvider`でラップしている。

テストでは`src/__mocks__/next-auth/react.js`と`src/__mocks__/next/navigation.js`を追加して`useSession`と`useRouter`をモックし、モーダルの表示と登録後の遷移を確認する（`AddBookConfirmModal.test.tsx`）。
