### PR TITLE
toastを表示

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "next-auth": "^5.0.0-beta.18",
         "react": "^18",
         "react-dom": "^18",
+        "react-hot-toast": "^2.4.1",
         "storybook-addon-module-mock": "^1.3.0"
       },
       "devDependencies": {
@@ -13526,6 +13527,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.14.tgz",
+      "integrity": "sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -18854,6 +18864,22 @@
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next-auth": "^5.0.0-beta.18",
     "react": "^18",
     "react-dom": "^18",
+    "react-hot-toast": "^2.4.1",
     "storybook-addon-module-mock": "^1.3.0"
   },
   "devDependencies": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,8 @@ import '@mantine/core/styles.css';
 import { MantineProvider } from '@mantine/core';
 import { Header } from '@/components/header/Header';
 import AuthGuard from '@/components/feature/AuthGuard';
+import { Toaster } from 'react-hot-toast';
+import { AuthToaster } from '@/components/auth/AuthToaster';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -26,7 +28,11 @@ export default function RootLayout({
         </MantineProvider>
         <main className="flex min-h-screen flex-col justify-center  p-24">
           <MantineProvider>
-            <AuthGuard>{children}</AuthGuard>
+            <AuthGuard>
+              <Toaster />
+              <AuthToaster />
+              {children}
+            </AuthGuard>
           </MantineProvider>
         </main>
       </body>

--- a/src/components/auth/AuthToaster.tsx
+++ b/src/components/auth/AuthToaster.tsx
@@ -5,32 +5,26 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 const messages = {
-  logOut: 'ログアウトしました。',
   success: 'ログインしました！',
 };
 
 export const AuthToaster = () => {
 
   const router = useRouter();
-  const [code, setCode] = useState<string | null>(null);
+  const [authenticated, setAuthenticated] = useState<string | null>(null);
 
   useEffect(() => {
-    // クライアントサイドでのみ実行されることを保証
-    const params = new URLSearchParams(window.location.search);
-    const authenticatedCode = params.get('authenticated');
-    setCode(authenticatedCode);
-  }, []);
-
-  useEffect(() => {
-    if (code) {
-      toast.success(messages.success);
-
-      // URLからauthenticatedパラメータを削除
       const params = new URLSearchParams(window.location.search);
-      params.delete('authenticated');
-      router.replace(`${window.location.pathname}?${params.toString()}`);
-    }
-  }, [code, router]);
+      const authenticatedParams = params.get('authenticated');
+      setAuthenticated(authenticatedParams);
+
+      if (authenticated === 'true') {
+        toast.success(messages.success);
+
+        params.delete('authenticated');
+        router.replace(`${window.location.pathname}?${params.toString()}`);
+      }
+  }, [authenticated, router]);
 
   return null;
 };

--- a/src/components/auth/AuthToaster.tsx
+++ b/src/components/auth/AuthToaster.tsx
@@ -9,21 +9,20 @@ const messages = {
 };
 
 export const AuthToaster = () => {
-
   const router = useRouter();
   const [authenticated, setAuthenticated] = useState<string | null>(null);
 
   useEffect(() => {
-      const params = new URLSearchParams(window.location.search);
-      const authenticatedParams = params.get('authenticated');
-      setAuthenticated(authenticatedParams);
+    const params = new URLSearchParams(window.location.search);
+    const authenticatedParams = params.get('authenticated');
+    setAuthenticated(authenticatedParams);
 
-      if (authenticated === 'true') {
-        toast.success(messages.success);
+    if (authenticated === 'true') {
+      toast.success(messages.success);
 
-        params.delete('authenticated');
-        router.replace(`${window.location.pathname}?${params.toString()}`);
-      }
+      params.delete('authenticated');
+      router.replace(`${window.location.pathname}?${params.toString()}`);
+    }
   }, [authenticated, router]);
 
   return null;

--- a/src/components/auth/AuthToaster.tsx
+++ b/src/components/auth/AuthToaster.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import toast from 'react-hot-toast';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const messages = {
+  logOut: 'ログアウトしました。',
+  success: 'ログインしました！',
+};
+
+export const AuthToaster = () => {
+
+  const router = useRouter();
+  const [code, setCode] = useState<string | null>(null);
+
+  useEffect(() => {
+    // クライアントサイドでのみ実行されることを保証
+    const params = new URLSearchParams(window.location.search);
+    const authenticatedCode = params.get('authenticated');
+    setCode(authenticatedCode);
+  }, []);
+
+  useEffect(() => {
+    if (code) {
+      toast.success(messages.success);
+
+      // URLからauthenticatedパラメータを削除
+      const params = new URLSearchParams(window.location.search);
+      params.delete('authenticated');
+      router.replace(`${window.location.pathname}?${params.toString()}`);
+    }
+  }, [code, router]);
+
+  return null;
+};

--- a/src/components/button/SignInButton.tsx
+++ b/src/components/button/SignInButton.tsx
@@ -6,7 +6,7 @@ const SignInButton = () => {
     <form
       action={async () => {
         'use server';
-        await signIn('google', {redirectTo: '/?authenticated=true'});
+        await signIn('google', { redirectTo: '/?authenticated=true' });
       }}
     >
       <GoogleButton type="submit">Signin with Google</GoogleButton>

--- a/src/components/button/SignInButton.tsx
+++ b/src/components/button/SignInButton.tsx
@@ -6,7 +6,7 @@ const SignInButton = () => {
     <form
       action={async () => {
         'use server';
-        await signIn('google');
+        await signIn('google', {redirectTo: '/?authenticated=true'});
       }}
     >
       <GoogleButton type="submit">Signin with Google</GoogleButton>

--- a/src/components/modal/AddBookConfirmContent.tsx
+++ b/src/components/modal/AddBookConfirmContent.tsx
@@ -2,6 +2,7 @@ import { Card, Image, Text, Button, Group } from '@mantine/core';
 import axios from 'axios';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
 
 type Book = {
   id: number;
@@ -32,6 +33,8 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
       });
       if (res.status === 200) {
         router.push('/');
+        router.refresh();
+        toast.success('本を保存しました！');
       } else {
         return false;
       }


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/60


## description
react-hot-toastを採用。
https://react-hot-toast.com/

`layout.tsx`に`Toaster`と`AuthToaster`を配置し、`AuthToaster.tsx`でクエリパラメータ`authenticated`を検知してログイン成功のトーストを表示する。表示後はそのパラメータを削除する。

あわせて`SignInButton.tsx`は`signIn('google', { redirectTo: ... })`でリダイレクト先を指定するように変更し、`AddBookConfirmContent.tsx`は登録成功時に`router.push`と`router.refresh`を実行したうえでトーストを表示するようにした。
