### PR TITLE
footer作成

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,17 @@
 import type { Preview } from '@storybook/react';
 import '@mantine/core/styles.css';
-import { MantineProvider } from '@mantine/core';
 import React from 'react';
+import { createTheme, MantineProvider } from '@mantine/core';
+
+const theme = createTheme({
+  breakpoints: {
+    xs: '30em',
+    sm: '48em',
+    md: '64em',
+    lg: '74em',
+    xl: '90em',
+  },
+});
 
 const preview: Preview = {
   parameters: {
@@ -14,7 +24,7 @@ const preview: Preview = {
   },
   decorators: [
     (Story) => (
-      <MantineProvider>
+      <MantineProvider theme={theme}>
         <Story />
       </MantineProvider>
     ),

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "cssVariables.lookupFiles": [
+    "**/*.css",
+    "**/*.scss",
+    "**/*.sass",
+    "**/*.less",
+    "node_modules/@mantine/core/styles.css"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "postcss": "^8",
         "postcss-preset-mantine": "^1.15.0",
+        "postcss-simple-vars": "^7.0.1",
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.14",
         "storybook": "^8.1.9",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8",
     "postcss-preset-mantine": "^1.15.0",
+    "postcss-simple-vars": "^7.0.1",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.14",
     "storybook": "^8.1.9",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -3,6 +3,15 @@ const config = {
   plugins: {
     tailwindcss: {},
     'postcss-preset-mantine': {},
+    'postcss-simple-vars': {
+      variables: {
+        'mantine-breakpoint-xs': '36em',
+        'mantine-breakpoint-sm': '48em',
+        'mantine-breakpoint-md': '62em',
+        'mantine-breakpoint-lg': '75em',
+        'mantine-breakpoint-xl': '88em',
+      },
+    },
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import '@mantine/core/styles.css';
 import { MantineProvider } from '@mantine/core';
 import { Header } from '@/components/header/Header';
+import { Footer } from '@/components/footer/Footer';
 import AuthGuard from '@/components/feature/AuthGuard';
 import { Toaster } from 'react-hot-toast';
 import { AuthToaster } from '@/components/auth/AuthToaster';
@@ -35,6 +36,9 @@ export default function RootLayout({
             </AuthGuard>
           </MantineProvider>
         </main>
+        <MantineProvider>
+          <Footer />
+        </MantineProvider>
       </body>
     </html>
   );

--- a/src/components/footer/Footer.module.css
+++ b/src/components/footer/Footer.module.css
@@ -1,0 +1,24 @@
+.footer {
+  margin-top: rem(120px);
+  border-top: rem(1px) solid
+    light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+}
+
+.inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: var(--mantine-spacing-xl);
+  padding-bottom: var(--mantine-spacing-xl);
+}
+@media (max-width: 36em) {
+  .inner {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 36em) {
+  .links {
+    margin-top: var(--mantine-spacing-md);
+  }
+}

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Container, Group, Anchor, rem, ActionIcon } from '@mantine/core';
+import classes from './Footer.module.css';
+import {
+  IconBrandTwitter,
+  IconBrandYoutube,
+  IconBrandInstagram,
+} from '@tabler/icons-react';
+import Image from 'next/image';
+
+const links = [
+  { link: '#', label: 'Contact' },
+  { link: '#', label: 'Privacy' },
+  { link: '#', label: 'Blog' },
+  { link: '#', label: 'Careers' },
+];
+
+export function Footer() {
+  const items = links.map((link) => (
+    <Anchor<'a'>
+      c="dimmed"
+      key={link.label}
+      href={link.link}
+      onClick={(event) => event.preventDefault()}
+      size="sm"
+    >
+      {link.label}
+    </Anchor>
+  ));
+
+  return (
+    <div className={classes.footer}>
+      <Container className={classes.inner}>
+        <Image src="Mantine logo.svg" alt="仮のロゴ" width={28} height={28} />
+        <Group className={classes.links}>{items}</Group>
+        <Group gap="xs" justify="flex-end" wrap="nowrap">
+          <ActionIcon size="lg" variant="default" radius="xl">
+            <IconBrandTwitter
+              style={{ width: rem(18), height: rem(18) }}
+              stroke={1.5}
+            />
+          </ActionIcon>
+          <ActionIcon size="lg" variant="default" radius="xl">
+            <IconBrandYoutube
+              style={{ width: rem(18), height: rem(18) }}
+              stroke={1.5}
+            />
+          </ActionIcon>
+          <ActionIcon size="lg" variant="default" radius="xl">
+            <IconBrandInstagram
+              style={{ width: rem(18), height: rem(18) }}
+              stroke={1.5}
+            />
+          </ActionIcon>
+        </Group>
+      </Container>
+    </div>
+  );
+}

--- a/src/stories/footer/Footer.stories.ts
+++ b/src/stories/footer/Footer.stories.ts
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Footer } from '@/components/footer/Footer';
+
+const meta: Meta<typeof Footer> = {
+  component: Footer,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Footer>;
+
+export const AppearenceTest: Story = {};


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/20

## description
Mantine UIのFootersを参考に、`src/components/footer/Footer.tsx`と`Footer.module.css`を追加し、`src/app/layout.tsx`に組み込んだ。ロゴ・リンク（Contact / Privacy / Blog / Careers）・SNSアイコンを並べた仮の内容で、リンク先は未設定。36em以下では縦並びになるようメディアクエリを定義した。

MantineのCSS変数がエディタ上で解決されず警告が出るため、`postcss-simple-vars`を導入して`postcss.config.mjs`にbreakpointを定義し、`.vscode/settings.json`に`cssVariables.lookupFiles`を追加した。Storybookの`preview.tsx`にも`createTheme`で同じbreakpointを設定している。
