### PR TITLE
AppShellを採用

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "tsundoku-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@mantine/core": "^7.11.0",
         "@mantine/form": "^7.10.1",
         "@mantine/hooks": "^7.11.0",
         "@mantine/tiptap": "^7.11.0",
@@ -3108,6 +3107,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.2.tgz",
       "integrity": "sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.0"
       }
@@ -3117,6 +3117,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
       "integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.0.0",
         "@floating-ui/utils": "^0.2.0"
@@ -3127,6 +3128,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.16.tgz",
       "integrity": "sha512-HEf43zxZNAI/E781QIVpYSF3K2VH4TTYZpqecjdsFkjsaU1EbaWcM++kw0HXFffj7gDUcBFevX8s0rQGQpxkow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.0",
         "@floating-ui/utils": "^0.2.0",
@@ -3142,6 +3144,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.0.tgz",
       "integrity": "sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -3154,7 +3157,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
       "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -4242,6 +4246,7 @@
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.11.0.tgz",
       "integrity": "sha512-yw2Llww9mw8rDWZtucdEuvkqqjHdreUibos7JCUpejL721FW1Tn9L91nsxO/YQFSS7jn4Q0CP+1YbQ/PMULmwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.26.9",
         "clsx": "^2.1.1",
@@ -4261,6 +4266,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.3.tgz",
       "integrity": "sha512-Q08/0IrpvM+NMY9PA2rti9Jb+JejTddwmwmVQGskAlhtcrw1wsRzoR6ode6mR+OAabNa75w/dxedSUY2mlphaQ==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -10399,6 +10405,7 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -19679,6 +19686,7 @@
       "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.3.4.tgz",
       "integrity": "sha512-2hHN5mbLuCDUx19bv0Q8wet67QqYK6xmtLQeY5xx+h7UXiMmRtaCwqko4mMPoKXLc6xAzwRrutg8XbTRlsfjRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prop-types": "^15.7.2"
       },
@@ -19702,6 +19710,7 @@
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
       "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.6",
         "react-style-singleton": "^2.2.1",
@@ -19772,6 +19781,7 @@
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
       "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
@@ -21534,7 +21544,8 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss": {
       "version": "3.4.3",
@@ -22848,6 +22859,7 @@
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
       "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -22857,6 +22869,7 @@
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },
@@ -22871,6 +22884,7 @@
       "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
       "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@mantine/core": "^7.11.0",
     "@mantine/form": "^7.10.1",
     "@mantine/hooks": "^7.11.0",
     "@mantine/tiptap": "^7.11.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,11 +4,10 @@ import './globals.css';
 import '@mantine/tiptap/styles.css';
 import '@mantine/core/styles.css';
 import { MantineProvider } from '@mantine/core';
-import { Header } from '@/components/header/Header';
-import { Footer } from '@/components/footer/Footer';
 import AuthGuard from '@/components/feature/AuthGuard';
 import { Toaster } from 'react-hot-toast';
 import { AuthToaster } from '@/components/auth/AuthToaster';
+import { MyAppShell } from '@/components/appShell/MyAppShell';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -25,21 +24,17 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <MantineProvider>
-          <Header />
-        </MantineProvider>
-        <main className="flex min-h-screen flex-col justify-center  p-24">
+        <main>
           <MantineProvider>
-            <AuthGuard>
-              <Toaster />
-              <AuthToaster />
-              {children}
-            </AuthGuard>
+            <MyAppShell>
+              <AuthGuard>
+                <Toaster />
+                <AuthToaster />
+                {children}
+              </AuthGuard>
+            </MyAppShell>
           </MantineProvider>
         </main>
-        <MantineProvider>
-          <Footer />
-        </MantineProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,11 @@
 import SearchBooksButton from '@/components/button/SearchBooksButton';
 import BookItems from '@/components/bookshelf/BookItems';
-import { auth } from '@/auth';
 
 export default async function Home() {
-  const session = await auth();
-  const res = await fetch(
-    `http://localhost:3001/api/books?email=${session?.user?.email}`,
-  );
-  const bookItems = await res.json();
   return (
     <div>
       <SearchBooksButton />
-      <BookItems bookItems={bookItems} />
+      <BookItems />
     </div>
   );
 }

--- a/src/components/appShell/MyAppShell.tsx
+++ b/src/components/appShell/MyAppShell.tsx
@@ -1,0 +1,28 @@
+import {
+  AppShell,
+  AppShellHeader,
+  AppShellMain,
+  AppShellFooter,
+} from '@mantine/core';
+import { Header } from '@/components/header/Header';
+import { auth } from '#auth';
+import SignInButton from '@/components/button/SignInButton';
+import { Footer } from '@/components/footer/Footer';
+import type { PropsWithChildren } from 'react';
+
+export async function MyAppShell({ children }: PropsWithChildren) {
+  const session = await auth();
+
+  return (
+    <AppShell header={{ height: 60 }} footer={{ height: 80 }} padding="md">
+      <AppShellHeader>
+        <Header />
+      </AppShellHeader>
+
+      <AppShellMain>{session ? children : <SignInButton />}</AppShellMain>
+      <AppShellFooter>
+        <Footer />
+      </AppShellFooter>
+    </AppShell>
+  );
+}

--- a/src/components/footer/Footer.module.css
+++ b/src/components/footer/Footer.module.css
@@ -1,24 +1,13 @@
-.footer {
-  margin-top: rem(120px);
-  border-top: rem(1px) solid
-    light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
-}
+.control {
+  display: block;
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+  border-radius: var(--mantine-radius-md);
+  font-weight: 500;
 
-.inner {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-top: var(--mantine-spacing-xl);
-  padding-bottom: var(--mantine-spacing-xl);
-}
-@media (max-width: 36em) {
-  .inner {
-    flex-direction: column;
-  }
-}
-
-@media (max-width: 36em) {
-  .links {
-    margin-top: var(--mantine-spacing-md);
+  @mixin hover {
+    background-color: light-dark(
+      var(--mantine-color-gray-0),
+      var(--mantine-color-dark-6)
+    );
   }
 }

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,39 +1,23 @@
-'use client';
-
-import { Container, Group, Anchor, rem, ActionIcon } from '@mantine/core';
-import classes from './Footer.module.css';
 import {
   IconBrandTwitter,
-  IconBrandYoutube,
-  IconBrandInstagram,
+  IconBrandGithub,
+  IconArticle,
 } from '@tabler/icons-react';
+import { Group, ActionIcon, UnstyledButton, rem } from '@mantine/core';
 import Image from 'next/image';
-
-const links = [
-  { link: '#', label: 'Contact' },
-  { link: '#', label: 'Privacy' },
-  { link: '#', label: 'Blog' },
-  { link: '#', label: 'Careers' },
-];
+import classes from './Footer.module.css';
 
 export function Footer() {
-  const items = links.map((link) => (
-    <Anchor<'a'>
-      c="dimmed"
-      key={link.label}
-      href={link.link}
-      onClick={(event) => event.preventDefault()}
-      size="sm"
-    >
-      {link.label}
-    </Anchor>
-  ));
-
   return (
-    <div className={classes.footer}>
-      <Container className={classes.inner}>
+    <Group h="100%" px="md">
+      <Group justify="space-between" style={{ flex: 1 }}>
         <Image src="Mantine logo.svg" alt="仮のロゴ" width={28} height={28} />
-        <Group className={classes.links}>{items}</Group>
+        <Group ml="xl" gap={0}>
+          <UnstyledButton className={classes.control}>Terms</UnstyledButton>
+          <UnstyledButton className={classes.control}>
+            Privacy policy
+          </UnstyledButton>
+        </Group>
         <Group gap="xs" justify="flex-end" wrap="nowrap">
           <ActionIcon size="lg" variant="default" radius="xl">
             <IconBrandTwitter
@@ -42,19 +26,19 @@ export function Footer() {
             />
           </ActionIcon>
           <ActionIcon size="lg" variant="default" radius="xl">
-            <IconBrandYoutube
+            <IconBrandGithub
               style={{ width: rem(18), height: rem(18) }}
               stroke={1.5}
             />
           </ActionIcon>
           <ActionIcon size="lg" variant="default" radius="xl">
-            <IconBrandInstagram
+            <IconArticle
               style={{ width: rem(18), height: rem(18) }}
               stroke={1.5}
             />
           </ActionIcon>
         </Group>
-      </Container>
-    </div>
+      </Group>
+    </Group>
   );
 }

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,24 +1,21 @@
-import classes from './HeaderTabs.module.css';
-import { Affix } from '@mantine/core';
-import UserMenu from './UserMenu';
 import { auth } from '#auth';
+import { Group } from '@mantine/core';
 import Image from 'next/image';
-import { Container } from '@mantine/core';
+import UserMenu from './UserMenu';
 
 export async function Header() {
   const session = await auth();
 
   return (
-    <Affix position={{ top: 0, left: 0, right: 0 }}>
-      <header className={classes.header}>
-        <Container size="md" className={classes.inner}>
-          <Image src="Mantine logo.svg" alt="仮のロゴ" width={28} height={28} />
-          {/* 前半でuserが存在してるのは確認してるため、name!と非nullアサーションを使用してundefinedではないことを確定させてる */}
+    <Group h="100%" px="md">
+      <Group justify="space-between" style={{ flex: 1 }}>
+        <Image src="Mantine logo.svg" alt="仮のロゴ" width={28} height={28} />
+        <Group ml="xl" gap={0}>
           {session?.user && (
             <UserMenu name={session.user.name!} image={session.user.image!} />
           )}
-        </Container>
-      </header>
-    </Affix>
+        </Group>
+      </Group>
+    </Group>
   );
 }

--- a/src/components/header/HeaderTabs.module.css
+++ b/src/components/header/HeaderTabs.module.css
@@ -1,26 +1,7 @@
-.header {
-  height: rem(56px);
-  margin-bottom: rem(120px);
-  background-color: var(--mantine-color-body);
-  border-bottom: rem(1px) solid
-    light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
-}
-
-.inner {
-  height: rem(56px);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.link {
+.control {
   display: block;
-  line-height: 1;
-  padding: rem(8px) rem(12px);
-  border-radius: var(--mantine-radius-sm);
-  text-decoration: none;
-  color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-0));
-  font-size: var(--mantine-font-size-sm);
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+  border-radius: var(--mantine-radius-md);
   font-weight: 500;
 
   @mixin hover {
@@ -28,10 +9,5 @@
       var(--mantine-color-gray-0),
       var(--mantine-color-dark-6)
     );
-  }
-
-  [data-mantine-color-scheme] &[data-active] {
-    background-color: var(--mantine-color-blue-filled);
-    color: var(--mantine-color-white);
   }
 }


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/72

## description
MantineのAppShellでページ全体のレイアウトを統一した。`src/components/appShell/MyAppShell.tsx`を追加し、`AppShellHeader`にHeader、`AppShellMain`にchildren、`AppShellFooter`にFooterを配置。`layout.tsx`はHeaderとFooterを個別の`MantineProvider`で囲む形をやめ、`MyAppShell`でchildrenごと包むようにした。セッションがない場合はmainにサインインボタンだけを表示する。

AppShellのレイアウトに合わせてFooterも作り直し、Containerとメディアクエリでの実装からGroupベースに変更。リンクはTermsとPrivacy policyに、アイコンはTwitter・GitHub・記事の3つに差し替えた。childrenの型には`PropsWithChildren`を使用している。
