### PR TITLE
本の章入力欄にデフォルトの値を設定

### DIFF
--- a/src/components/modal/AddBookConfirmContent.tsx
+++ b/src/components/modal/AddBookConfirmContent.tsx
@@ -53,7 +53,7 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
 
       <Group justify="space-between" mt="md" mb="xs">
         <Text fw={500}>{book.title}を本棚に追加しますか？</Text>
-        <NumberInput label="章の数" min={1} ref={ref} />
+        <NumberInput label="章の数" defaultValue={1} min={1} ref={ref} />
       </Group>
 
       <Button color="blue" mt="md" radius="md" onClick={handleSubmit}>

--- a/src/types/Book.ts
+++ b/src/types/Book.ts
@@ -1,0 +1,10 @@
+export type Book = {
+  id: number;
+  title: string;
+  author: string;
+  cover_image_url: string;
+};
+
+export type BookProps = {
+  book: Book;
+};


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/69

## description
本の登録確認モーダルの章の数の入力欄に`defaultValue={1}`を設定し、未入力のまま登録されないようにした。エラー表示は行わない。

あわせて`src/types/Book.ts`を追加し、モーダル内で定義していたBookとBookPropsの型を切り出した。
