### PR TITLE
Sessionにuidを追加

### DIFF
--- a/src/app/books/[bookId]/memos/page.tsx
+++ b/src/app/books/[bookId]/memos/page.tsx
@@ -18,7 +18,7 @@ export default function Page() {
 }
 
 type memoParams = {
-  email: string | undefined | null;
+  uid: string | undefined;
   book_id: number;
 };
 
@@ -50,7 +50,7 @@ function PageContent() {
   const apiUrl = `http://localhost:3001/api/books/${bookId}/memos`;
   const { data: session, status } = useSession();
   const params = {
-    email: session?.user?.email,
+    uid: session?.user?.id,
     book_id: bookId,
   };
   const [bookWithMemos, setBookWithMemos] = useState<BookWithMemo>();

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,10 +5,24 @@ import axios from 'axios';
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [Google],
   callbacks: {
-    async signIn({ user }) {
+    async jwt({ token, profile }) {
+      if (profile) {
+        token.sub = profile.sub || undefined;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (token.sub) {
+        session.user.id = token.sub;
+      }
+      return session;
+    },
+
+    async signIn({ user, profile }) {
       const name = user.name;
       const email = user.email;
       const avatarUrl = user.image;
+      const uid = profile?.sub;
       try {
         const res = await axios.post(
           'http://localhost:3001/api/auth/callback/google',
@@ -16,6 +30,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             name,
             email,
             avatarUrl,
+            uid,
           },
         );
         if (res.status === 200) {

--- a/src/components/bookshelf/BookItems.tsx
+++ b/src/components/bookshelf/BookItems.tsx
@@ -1,6 +1,7 @@
 import BookItem from './BookItem';
 import { SimpleGrid } from '@mantine/core';
 import { auth } from '@/auth';
+import axios from 'axios';
 
 type BookResponse = {
   id: number;
@@ -21,11 +22,9 @@ type Book = {
 const BookItems = async () => {
   const getBooks = async () => {
     const session = await auth();
-    const res = await fetch(
-      `http://localhost:3001/api/books?email=${session?.user?.email}`,
-    );
-    const data = await res.json();
-    return data.map((book: BookResponse) => ({
+    const params = { uid: session?.user?.id };
+    const res = await axios.get('http://localhost:3001/api/books', { params });
+    return res.data.map((book: BookResponse) => ({
       id: book.id,
       title: book.title,
       author: book.author,

--- a/src/components/modal/AddBookConfirmContent.tsx
+++ b/src/components/modal/AddBookConfirmContent.tsx
@@ -25,14 +25,14 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
     const title = book.title;
     const author = book.author;
     const coverImageUrl = book.imageUrl;
-    const email = session?.user?.email;
+    const uid = session?.user?.id;
     const headingNumber = ref.current?.value;
     try {
       const res = await axios.post('http://localhost:3001/api/books', {
         title,
         author,
         coverImageUrl,
-        email,
+        uid,
         headingNumber,
       });
       if (res.status === 200) {
@@ -43,7 +43,7 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
         return false;
       }
     } catch (error) {
-      console.error(error);
+      return false;
     }
   };
 


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/75

## description
毎回メールアドレスでUserの情報を検証していたので、GoogleAccountIDに変更。

Auth.jsの`jwt`コールバックで`profile.sub`を`token.sub`に入れ、`session`コールバックで`session.user.id`として取り出せるようにした。`signIn`コールバックではRailsへのPOSTに`uid`を追加。本の一覧取得・本の登録・メモ取得のリクエストも、emailではなく`session.user.id`を`uid`として送る形に変更している。あわせて本の一覧取得を`fetch`から`axios`に揃えた。
