### PR TITLE
loading画面を実装

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader, Center } from '@mantine/core';
+
+export default function Loading() {
+  return (
+    <Center style={{ width: '100vw', height: '80vh' }}>
+      <Loader color="blue" type="dots" size="xl" />
+    </Center>
+  );
+}


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/58

## description
`src/app/loading.tsx`を追加し、読み込み中は画面中央にMantineのLoader（dotsタイプ）を表示するようにした。Skeletonはデザインの手間が大きいため見送っている。
