### PR TITLE
ログ機能実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "@tiptap/pm": "^2.4.0",
         "@tiptap/react": "^2.4.0",
         "@tiptap/starter-kit": "^2.4.0",
+        "@uiw/react-heat-map": "^2.2.2",
+        "@uiw/react-tooltip": "^4.22.3",
         "axios": "^1.7.2",
         "highlight.js": "^11.9.0",
         "lowlight": "^3.1.0",
@@ -8045,6 +8047,98 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uiw/react-heat-map": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@uiw/react-heat-map/-/react-heat-map-2.2.2.tgz",
+      "integrity": "sha512-9aNjDd8fz6tXhWj5rQ8+5MmQRhDQOfOri2CeIyMjnHunPBagg49FIPEu7H/5pRet0JD6pUrfSyMf+UpZNX5FgA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.10.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-overlay": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-overlay/-/react-overlay-4.22.3.tgz",
+      "integrity": "sha512-SFHY3kU3Citpf/QdXzQQzMyMpQ/fpLPIoOSS1xwBQgRTqcGR7h7yjSpNYfZxK5xS6/MxFs3HzFvln+IVDOTW1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/react-portal": "^4.22.3",
+        "@uiw/utils": "^4.22.3",
+        "react-transition-group": "~4.4.2"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-overlay-trigger": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-overlay-trigger/-/react-overlay-trigger-4.22.3.tgz",
+      "integrity": "sha512-7YT+kaPCpMYWwmOPFGf4AHPJsEVswgqzDSUdDbqIz/NWbQbl5+4hCbqsz3xEnIL5EW+plKnKq4E3Ou3DjRqPiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/react-overlay": "^4.22.3",
+        "@uiw/utils": "^4.22.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-portal": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-portal/-/react-portal-4.22.3.tgz",
+      "integrity": "sha512-YvTJBNdc0uPsfI2Spuo0ThnavMjdzNn1d0NNv0zoIDkZ30ccxL3USSORzhg5T3SjBFwLxFQ1VxaP7nCJJEVL3Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-tooltip": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-tooltip/-/react-tooltip-4.22.3.tgz",
+      "integrity": "sha512-wGn7tWKUK5Ara0M5+ASSWqaCHYzIOYp9DIlzyQ12D06h06IUtzt2vIAbH0ovLNRhCYAuWyBJI6tV65jAkYFfTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/react-overlay-trigger": "^4.22.3",
+        "@uiw/utils": "^4.22.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/utils": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/@uiw/utils/-/utils-4.22.3.tgz",
+      "integrity": "sha512-XEi6PBE7mvL1P+6Wa/+npKmmDovkVeXpw0XDfsdrmaRXYTUc05RYXyOy3olVmglgutagTQlCUJzAP+GXaSgw/A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
@@ -11503,6 +11597,16 @@
       "license": "MIT",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -19792,6 +19896,22 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@tiptap/pm": "^2.4.0",
     "@tiptap/react": "^2.4.0",
     "@tiptap/starter-kit": "^2.4.0",
+    "@uiw/react-heat-map": "^2.2.2",
+    "@uiw/react-tooltip": "^4.22.3",
     "axios": "^1.7.2",
     "highlight.js": "^11.9.0",
     "lowlight": "^3.1.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 import SearchBooksButton from '@/components/button/SearchBooksButton';
 import BookItems from '@/components/bookshelf/BookItems';
+import Cal from '@/components/Cal/Cal';
 
 export default async function Home() {
   return (
     <div>
       <SearchBooksButton />
       <BookItems />
+      <Cal />
     </div>
   );
 }

--- a/src/components/Cal/Cal.tsx
+++ b/src/components/Cal/Cal.tsx
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import CalContent from './CalContent';
+import { auth } from '@/auth';
+
+export default async function Cal() {
+  const session = await auth();
+  const params = { uid: session?.user?.id };
+  const res = await axios.get('http://localhost:3001/api/reading_logs', { params });
+  const readingLogs = res.data;
+
+  return <CalContent readingLogs={readingLogs} />;
+}

--- a/src/components/Cal/Cal.tsx
+++ b/src/components/Cal/Cal.tsx
@@ -5,7 +5,9 @@ import { auth } from '@/auth';
 export default async function Cal() {
   const session = await auth();
   const params = { uid: session?.user?.id };
-  const res = await axios.get('http://localhost:3001/api/reading_logs', { params });
+  const res = await axios.get('http://localhost:3001/api/reading_logs', {
+    params,
+  });
   const readingLogs = res.data;
 
   return <CalContent readingLogs={readingLogs} />;

--- a/src/components/Cal/CalContent.tsx
+++ b/src/components/Cal/CalContent.tsx
@@ -40,7 +40,10 @@ export default function CalContent({ readingLogs }: CalContentProps) {
         }}
         rectRender={(props, data) => {
           return (
-            <Tooltip placement="top" content={`${data.count || 0} logs on ${data.date}`}>
+            <Tooltip
+              placement="top"
+              content={`${data.count || 0} logs on ${data.date}`}
+            >
               <rect {...props} />
             </Tooltip>
           );

--- a/src/components/Cal/CalContent.tsx
+++ b/src/components/Cal/CalContent.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { ScrollArea } from '@mantine/core';
+import HeatMap from '@uiw/react-heat-map';
+
+type ReadingLog = {
+  date: string;
+  count: number;
+};
+
+type CalContentProps = {
+  readingLogs: ReadingLog[];
+};
+
+export default function CalContent({readingLogs}: CalContentProps) {
+  const value = readingLogs.map(log => ({
+    date: log.date.replace('-', '/'),
+    count: log.count,
+  }))
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  return (
+    <ScrollArea w={600}>
+      <HeatMap
+        value={value}
+        width={720}
+        weekLabels={['', 'Mon', '', 'Wed', '', 'Fri', '']}
+        startDate={new Date(`${currentYear}/01/01`)}
+        endDate={today}
+        rectProps={{ rx: 3.5 }}
+        rectSize={12}
+        legendCellSize={0}
+        space={2.4}
+        panelColors={{
+          1: '#c6e48b',
+          2: '#32CD32',
+          4: '#009900',
+          6: '#006400',
+        }}
+  
+      />
+    </ScrollArea>
+  );
+};

--- a/src/components/Cal/CalContent.tsx
+++ b/src/components/Cal/CalContent.tsx
@@ -2,6 +2,7 @@
 
 import { ScrollArea } from '@mantine/core';
 import HeatMap from '@uiw/react-heat-map';
+import Tooltip from '@uiw/react-tooltip';
 
 type ReadingLog = {
   date: string;
@@ -36,6 +37,13 @@ export default function CalContent({ readingLogs }: CalContentProps) {
           2: '#32CD32',
           4: '#009900',
           6: '#006400',
+        }}
+        rectRender={(props, data) => {
+          return (
+            <Tooltip placement="top" content={`${data.count || 0} logs on ${data.date}`}>
+              <rect {...props} />
+            </Tooltip>
+          );
         }}
       />
     </ScrollArea>

--- a/src/components/Cal/CalContent.tsx
+++ b/src/components/Cal/CalContent.tsx
@@ -12,11 +12,11 @@ type CalContentProps = {
   readingLogs: ReadingLog[];
 };
 
-export default function CalContent({readingLogs}: CalContentProps) {
-  const value = readingLogs.map(log => ({
+export default function CalContent({ readingLogs }: CalContentProps) {
+  const value = readingLogs.map((log) => ({
     date: log.date.replace('-', '/'),
     count: log.count,
-  }))
+  }));
   const today = new Date();
   const currentYear = today.getFullYear();
   return (
@@ -37,8 +37,7 @@ export default function CalContent({readingLogs}: CalContentProps) {
           4: '#009900',
           6: '#006400',
         }}
-  
       />
     </ScrollArea>
   );
-};
+}

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -12,7 +12,9 @@ export function Footer() {
   return (
     <Group h="100%" px="md">
       <Group justify="space-between" style={{ flex: 1 }}>
-        <Image src="Mantine logo.svg" alt="仮のロゴ" width={28} height={28} />
+        <Link href={'/'}>
+          <Image src="Mantine logo.svg" alt="仮のロゴ" width={28} height={28} />
+        </Link>
         <Group ml="xl" gap={0}>
           <Link href={'/terms'}>
             <UnstyledButton className={classes.control}>Terms</UnstyledButton>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,6 +2,7 @@ import { auth } from '#auth';
 import { Group } from '@mantine/core';
 import Image from 'next/image';
 import UserMenu from './UserMenu';
+import Link from 'next/link';
 
 export async function Header() {
   const session = await auth();
@@ -9,7 +10,9 @@ export async function Header() {
   return (
     <Group h="100%" px="md">
       <Group justify="space-between" style={{ flex: 1 }}>
-        <Image src="Mantine logo.svg" alt="仮のロゴ" width={28} height={28} />
+        <Link href={'/'}>
+          <Image src="Mantine logo.svg" alt="仮のロゴ" width={28} height={28} />
+        </Link>
         <Group ml="xl" gap={0}>
           {session?.user && (
             <UserMenu name={session.user.name!} image={session.user.image!} />


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/13

## description
ルートにログコンポーネントを配置。
カーソルを合わせた時に出るポップアップは開発環境だと、表示がおかしいが問題なし。

`@uiw/react-heat-map`で草を表示する。データ取得はサーバーコンポーネントの`Cal`が担当し、表示だけを行う`CalContent`にreadingLogsを渡す構成にした。クライアントコンポーネント内で`useSession`を使うとuidがnullになったため。

草の濃さは`panelColors`で4段階に指定し、下部の凡例は`legendCellSize={0}`で非表示にした。`rectRender`で`@uiw/react-tooltip`を差し込み、日付とログ数を出している。あわせてヘッダーとフッターのロゴからルートへのリンクを張った。
