### PR TITLE
著者でも検索できるように実装

### DIFF
--- a/src/components/search/SearchForm.tsx
+++ b/src/components/search/SearchForm.tsx
@@ -68,7 +68,7 @@ const SearchForm = ({ onResults }: SearchFormProps) => {
             <TextInput
               radius={'xl'}
               size="md"
-              label='検索'
+              label="検索"
               placeholder="本のタイトルや著者"
               rightSectionWidth={42}
               leftSection={

--- a/src/components/search/SearchForm.tsx
+++ b/src/components/search/SearchForm.tsx
@@ -68,6 +68,7 @@ const SearchForm = ({ onResults }: SearchFormProps) => {
             <TextInput
               radius={'xl'}
               size="md"
+              label='検索'
               placeholder="本のタイトルや著者"
               rightSectionWidth={42}
               leftSection={

--- a/src/components/search/SearchForm.tsx
+++ b/src/components/search/SearchForm.tsx
@@ -1,8 +1,24 @@
-import { TextInput, useMantineTheme, ActionIcon, rem } from '@mantine/core';
+import {
+  TextInput,
+  useMantineTheme,
+  ActionIcon,
+  rem,
+  Grid,
+  GridCol,
+  Container,
+  Menu,
+  Button,
+  MenuTarget,
+  MenuItem,
+  MenuLabel,
+  MenuDropdown,
+} from '@mantine/core';
 import { IconSearch, IconArrowRight } from '@tabler/icons-react';
 import { useForm } from '@mantine/form';
 import axios from 'axios';
 import { SearchFormProps, Item } from '@/types/index';
+import { IconChevronDown } from '@tabler/icons-react';
+import { useState } from 'react';
 
 const SearchForm = ({ onResults }: SearchFormProps) => {
   const theme = useMantineTheme();
@@ -12,12 +28,26 @@ const SearchForm = ({ onResults }: SearchFormProps) => {
       searchWord: '',
     },
   });
+  const data = [
+    { label: 'title', target: 'タイトル' },
+    { label: 'author', target: '著者' },
+  ];
+  const [selected, setSelected] = useState(data[0]);
+
+  const items = data.map((item) => (
+    <MenuItem onClick={() => setSelected(item)} key={item.label}>
+      {item.target}
+    </MenuItem>
+  ));
 
   const handleSubmit = async (values: { searchWord: string }) => {
+    const url = `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404`;
+    const params =
+      selected.label === 'title'
+        ? { applicationId: '1063966721330772407', title: values.searchWord }
+        : { applicationId: '1063966721330772407', author: values.searchWord };
     try {
-      const res = await axios.get(
-        `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?applicationId=1063966721330772407&title=${values.searchWord}`,
-      );
+      const res = await axios.get(url, { params });
       const books = res.data.Items.map((element: Item, index: number) => ({
         id: index + 1,
         title: element.Item.title,
@@ -31,37 +61,60 @@ const SearchForm = ({ onResults }: SearchFormProps) => {
   };
 
   return (
-    <form onSubmit={form.onSubmit(handleSubmit)}>
-      <TextInput
-        radius={'xl'}
-        size="md"
-        label="検索"
-        placeholder="本のタイトル"
-        rightSectionWidth={42}
-        leftSection={
-          <IconSearch
-            style={{ width: rem(18), height: rem(18) }}
-            stroke={1.5}
-          />
-        }
-        rightSection={
-          <ActionIcon
-            size={32}
-            radius="xl"
-            color={theme.primaryColor}
-            variant="filled"
-            onClick={() => form.onSubmit(handleSubmit)()}
-          >
-            <IconArrowRight
-              style={{ width: rem(18), height: rem(18) }}
-              stroke={1.5}
+    <Container my="md">
+      <Grid>
+        <GridCol offset={1} span={9}>
+          <form onSubmit={form.onSubmit(handleSubmit)}>
+            <TextInput
+              radius={'xl'}
+              size="md"
+              placeholder="本のタイトルや著者"
+              rightSectionWidth={42}
+              leftSection={
+                <IconSearch
+                  style={{ width: rem(18), height: rem(18) }}
+                  stroke={1.5}
+                />
+              }
+              rightSection={
+                <ActionIcon
+                  size={32}
+                  radius="xl"
+                  color={theme.primaryColor}
+                  variant="filled"
+                  onClick={() => form.onSubmit(handleSubmit)()}
+                >
+                  <IconArrowRight
+                    style={{ width: rem(18), height: rem(18) }}
+                    stroke={1.5}
+                  />
+                </ActionIcon>
+              }
+              key={form.key('searchWord')}
+              {...form.getInputProps('searchWord')}
             />
-          </ActionIcon>
-        }
-        key={form.key('searchWord')}
-        {...form.getInputProps('searchWord')}
-      />
-    </form>
+          </form>
+        </GridCol>
+        <GridCol span={2}>
+          {' '}
+          <Menu shadow="md" width={200}>
+            <MenuTarget>
+              <Button
+                variant="default"
+                rightSection={<IconChevronDown size={14} />}
+              >
+                {selected.target}
+              </Button>
+            </MenuTarget>
+
+            <MenuDropdown>
+              <MenuLabel>検索条件</MenuLabel>
+              {items}
+            </MenuDropdown>
+          </Menu>
+        </GridCol>
+      </Grid>
+    </Container>
   );
 };
 

--- a/src/components/search/SearchHome.tsx
+++ b/src/components/search/SearchHome.tsx
@@ -16,7 +16,7 @@ const SearchHome = () => {
   return (
     <Container my="md">
       <Grid>
-        <GridCol offset={2} span={8}>
+        <GridCol>
           <SearchForm onResults={handleResults} />
         </GridCol>
         <GridCol>


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/47

## description
タイトルか著者かを選んで検索できるようにした。楽天ブックス書籍検索APIではURLでのand / or検索ができなかったため、Menuで検索対象を選ばせ、`title`か`author`のどちらかをリクエストのパラメータに渡す形にしている。

あわせて、クエリ文字列を直接組み立てていた箇所をaxiosの`params`に変更し、プレースホルダーも「本のタイトルや著者」に更新した。
