### PR TITLE
リクエストの最適化

### DIFF
--- a/src/__tests__/feature/SearchForm.tsx
+++ b/src/__tests__/feature/SearchForm.tsx
@@ -29,7 +29,7 @@ mockedAxiosGet.mockResolvedValue(mockResults);
 describe('SearchHome', () => {
   it('show book search results', async () => {
     render(<SearchHome />);
-    const textInput = screen.getByRole('textbox', { name: '検索' });
+    const textInput = screen.getByRole('textbox', { name: 'search' });
     const value = 'テスト';
     await user.type(textInput, value);
     await user.keyboard('{Enter}');

--- a/src/__tests__/feature/modal/AddBookConfirmModal.test.tsx
+++ b/src/__tests__/feature/modal/AddBookConfirmModal.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { render } from '@/test-utils/render';
 import Results from '@/components/search/Results';
-import AddBookConfirmContent from '@/components/modal/AddBookConfirmContent';
+import AddBookConfirmModal from '@/components/modal/AddBookConfirmModal';
 import axios from 'axios';
 import userEvent from '@testing-library/user-event';
 import { useRouter } from 'next/navigation';
@@ -40,7 +40,7 @@ describe('AddBookConfirmModal', () => {
   });
 
   it('should call router.push on book addition', async () => {
-    render(<AddBookConfirmContent book={mockBook} />);
+    render(<AddBookConfirmModal book={mockBook} />);
     const value = '追加';
     await user.click(screen.getByText(value));
     expect(useRouter().push).toHaveBeenCalledWith('/');

--- a/src/app/books/[bookId]/memos/page.tsx
+++ b/src/app/books/[bookId]/memos/page.tsx
@@ -68,10 +68,8 @@ function PageContent() {
       const headingRes = await axios.patch(
         `http://localhost:3001/api/headings/${headingId}`,
         {
-          heading: {
-            id: headingId,
-            title: title,
-          },
+          id: headingId,
+          title: title,
         },
       );
       const memoRes = await axios.patch(`${apiMemoUrl}/${memoId}`, {

--- a/src/app/books/[bookId]/memos/page.tsx
+++ b/src/app/books/[bookId]/memos/page.tsx
@@ -66,7 +66,7 @@ function PageContent() {
     const headingId = bookWithMemos?.headings[Number(heading) - 1].id;
     try {
       const headingRes = await axios.patch(
-        'http://localhost:3001/api/headings',
+        `http://localhost:3001/api/headings/${headingId}`,
         {
           heading: {
             id: headingId,
@@ -74,13 +74,13 @@ function PageContent() {
           },
         },
       );
-      const memoRes = await axios.patch(apiMemoUrl, {
+      const memoRes = await axios.patch(`${apiMemoUrl}/${memoId}`, {
         memo: {
           id: memoId,
           body: content,
         },
       });
-      const logRes = await axios.patch(
+      const logRes = await axios.post(
         'http://localhost:3001/api/reading_logs',
         {
           memoId: memoId,

--- a/src/app/books/[bookId]/memos/page.tsx
+++ b/src/app/books/[bookId]/memos/page.tsx
@@ -80,7 +80,17 @@ function PageContent() {
           body: content,
         },
       });
-      if (headingRes.status === 200 && memoRes.status === 200) {
+      const logRes = await axios.patch(
+        'http://localhost:3001/api/reading_logs',
+        {
+          memoId: memoId,
+        },
+      );
+      if (
+        headingRes.status === 200 &&
+        memoRes.status === 200 &&
+        logRes.status === 200
+      ) {
         setBookWithMemos((bookWithMemos) => {
           if (!bookWithMemos) return bookWithMemos;
 

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -8,19 +8,22 @@ import axios from 'axios';
 import { useState } from 'react';
 import { BookResponse, Book, Log } from '@/types/index';
 import { Container, Space, Paper } from '@mantine/core';
+import { UserParams } from '@/types/index';
 
 export default function Page() {
   const dynamicParams = useParams();
+  const params = { uid: dynamicParams.id };
+  const apiUrl = `http://localhost:3001/api/users/${dynamicParams.id}`;
   const [bookItems, setBookItems] = useState<Book[]>([]);
   const [readingLogs, setReadingLogs] = useState<Log[]>([]);
 
-  function fetcher(url: string) {
-    return axios.get(url).then((res) => res.data);
+  function fetcher(url: string, params: UserParams) {
+    return axios.get(url, { params }).then((res) => res.data);
   }
 
   const { error, isLoading } = useSWR(
-    `http://localhost:3001/api/users/${dynamicParams.id}`,
-    fetcher,
+    [apiUrl, params],
+    ([url, params]) => fetcher(url, params),
     {
       onSuccess: (data) => {
         const fetchedBookItems = data.books.map((book: BookResponse) => ({

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -7,7 +7,7 @@ import useSWR from 'swr';
 import axios from 'axios';
 import { useState } from 'react';
 import { BookResponse, Book, Log } from '@/types/index';
-import { Container, Space, Paper, Text } from '@mantine/core';
+import { Container, Space, Paper } from '@mantine/core';
 
 export default function Page() {
   const dynamicParams = useParams();
@@ -43,7 +43,6 @@ export default function Page() {
       <BookItems bookItems={bookItems} />
       <Space h={60} />
       <Paper withBorder shadow="xs" radius="md" p="xl">
-        <Text ta={'center'}>毎日、コツコツと。</Text>
         <Space h={20} />
         <CalContent readingLogs={readingLogs} />
       </Paper>

--- a/src/components/button/AddBookConfirmButton.tsx
+++ b/src/components/button/AddBookConfirmButton.tsx
@@ -1,7 +1,6 @@
 import { useDisclosure } from '@mantine/hooks';
 import { Modal, Button } from '@mantine/core';
-import AddBookConfirmContent from '../modal/AddBookConfirmContent';
-import { SessionProvider } from 'next-auth/react';
+import AddBookConfirmModal from '../modal/AddBookConfirmModal';
 import { BookProps } from '@/types/index';
 import { IconBookUpload } from '@tabler/icons-react';
 
@@ -9,9 +8,9 @@ const AddBookConfirmButton = ({ book }: BookProps) => {
   const [opened, { open, close }] = useDisclosure(false);
 
   return (
-    <SessionProvider>
+    <>
       <Modal opened={opened} onClose={close} title="" centered>
-        <AddBookConfirmContent book={book} />
+        <AddBookConfirmModal book={book} />
       </Modal>
 
       <Button
@@ -22,7 +21,7 @@ const AddBookConfirmButton = ({ book }: BookProps) => {
       >
         本棚に追加
       </Button>
-    </SessionProvider>
+    </>
   );
 };
 

--- a/src/components/header/UserMenu.tsx
+++ b/src/components/header/UserMenu.tsx
@@ -23,8 +23,11 @@ export default function UserMenu({ name, image, id }: UserInfo) {
   const clipboard = useClipboard();
 
   const handleDeleteUser = async () => {
+    const params = { uid: id };
     try {
-      const res = await axios.delete(`http://localhost:3001/api/users/${id}`);
+      const res = await axios.delete(`http://localhost:3001/api/users/${id}`, {
+        params,
+      });
       if (res.status === 204) {
         handleSignOut();
       } else {

--- a/src/components/modal/AddBookConfirmModal.tsx
+++ b/src/components/modal/AddBookConfirmModal.tsx
@@ -5,6 +5,15 @@ import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { useRef } from 'react';
 import { BookProps } from '@/types/index';
+import { SessionProvider } from 'next-auth/react';
+
+export default function AddBookConfirmModal({ book }: BookProps) {
+  return (
+    <SessionProvider>
+      <AddBookConfirmContent book={book} />
+    </SessionProvider>
+  );
+}
 
 const AddBookConfirmContent = ({ book }: BookProps) => {
   const { data: session } = useSession();
@@ -52,5 +61,3 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
     </Card>
   );
 };
-
-export default AddBookConfirmContent;

--- a/src/components/search/SearchForm.tsx
+++ b/src/components/search/SearchForm.tsx
@@ -68,7 +68,7 @@ const SearchForm = ({ onResults }: SearchFormProps) => {
             <TextInput
               radius={'xl'}
               size="md"
-              label="検索"
+              aria-label="search"
               placeholder="本のタイトルや著者"
               rightSectionWidth={42}
               leftSection={

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -3,3 +3,7 @@ export type UserInfo = {
   image: string;
   id: string;
 };
+
+export type UserParams = {
+  uid: string | string[];
+};


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/88
- https://github.com/reckyy/tsundoku/issues/65
- https://github.com/reckyy/tsundoku/issues/82

## description
backend PR #15 のルーティングとコントローラーの変更に合わせて、フロント側を対応させた。

章の更新は`api/headings/:id`、メモの更新は`api/books/:bookId/memos/:memoId`にリクエスト先を変更。メモの保存後に`POST api/reading_logs`で読書ログを作るようにし、3つのリクエストがすべて成功した場合のみ画面のstateを更新する。

セッションの取得も見直した。検索結果の件数だけ`SessionProvider`が作られていたため、`AddBookConfirmButton`から外してモーダル側の`AddBookConfirmModal`でラップする形に変更した。

あわせて、退会と公開ページの取得でuidをクエリパラメータとして渡すようにし、`UserParams`型を追加している。
