### PR TITLE
本の削除機能実装

### DIFF
--- a/src/components/bookshelf/BookItem.tsx
+++ b/src/components/bookshelf/BookItem.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Image } from '@mantine/core';
-import Link from 'next/link';
+import { BackgroundImage, Image, Group } from '@mantine/core';
 import { useSession, SessionProvider } from 'next-auth/react';
 import { BookProps } from '@/types/index';
+import BookMenu from './BookMenu';
 
 const BookItemContent = ({ book }: BookProps) => {
   const { data: session } = useSession();
@@ -11,15 +11,11 @@ const BookItemContent = ({ book }: BookProps) => {
   return (
     <>
       {session ? (
-        <Link href={`/books/${book.id}/memos`}>
-          <Image
-            radius="md"
-            w={141}
-            h={200}
-            src={book.coverImageUrl}
-            alt={book.title}
-          />
-        </Link>
+        <BackgroundImage radius="md" w={141} h={200} src={book.coverImageUrl}>
+          <Group justify="flex-end">
+            <BookMenu bookId={book.id} uid={session?.user?.id} />
+          </Group>
+        </BackgroundImage>
       ) : (
         <Image
           radius="md"

--- a/src/components/bookshelf/BookMenu.tsx
+++ b/src/components/bookshelf/BookMenu.tsx
@@ -1,0 +1,78 @@
+import {
+  Menu,
+  Group,
+  ActionIcon,
+  rem,
+  MenuTarget,
+  MenuItem,
+  MenuDropdown,
+} from '@mantine/core';
+import { IconEdit, IconTrash, IconDots } from '@tabler/icons-react';
+import Link from 'next/link';
+import { BookMenuProps } from '@/types/book';
+import { useDisclosure } from '@mantine/hooks';
+import { Modal } from '@mantine/core';
+import DeleteBookConfirmModal from '../modal/DeleteBookConfirmModal';
+
+export default function BookMenu({ bookId, uid }: BookMenuProps) {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  return (
+    <Group justify="center">
+      <Modal
+        opened={opened}
+        radius="md"
+        onClose={close}
+        withCloseButton={false}
+        centered
+      >
+        <DeleteBookConfirmModal
+          params={{ bookId: bookId, uid: uid }}
+          close={close}
+        />
+      </Modal>
+      <Menu
+        withArrow
+        width={100}
+        position="bottom"
+        transitionProps={{ transition: 'pop' }}
+        withinPortal
+      >
+        <MenuTarget>
+          <ActionIcon variant="default">
+            <IconDots
+              style={{ width: rem(16), height: rem(16) }}
+              stroke={1.5}
+            />
+          </ActionIcon>
+        </MenuTarget>
+        <MenuDropdown>
+          <Link href={`/books/${bookId}/memos`}>
+            <MenuItem
+              leftSection={
+                <IconEdit
+                  style={{ width: rem(16), height: rem(16) }}
+                  stroke={1.5}
+                />
+              }
+            >
+              メモ
+            </MenuItem>
+          </Link>
+          <MenuItem
+            color="red"
+            onClick={open}
+            leftSection={
+              <IconTrash
+                style={{ width: rem(16), height: rem(16) }}
+                stroke={1.5}
+              />
+            }
+          >
+            削除
+          </MenuItem>
+        </MenuDropdown>
+      </Menu>
+    </Group>
+  );
+}

--- a/src/components/modal/DeleteBookConfirmModal.tsx
+++ b/src/components/modal/DeleteBookConfirmModal.tsx
@@ -1,0 +1,56 @@
+import { Text, Divider, Group, Button, Space } from '@mantine/core';
+import { IconTrash } from '@tabler/icons-react';
+import axios from 'axios';
+import { DeleteBookModalProps } from '@/types/book';
+import toast from 'react-hot-toast';
+import { useRouter } from 'next/navigation';
+
+export default function DeleteBookConfirmModal({
+  params,
+  close,
+}: DeleteBookModalProps) {
+  const router = useRouter();
+  const handleDeleteBook = async () => {
+    const deleteBookApiUrl = `http://localhost:3001/api/user_books/${params.bookId}`;
+    try {
+      const res = await axios.delete(deleteBookApiUrl, {
+        params,
+      });
+      if (res.status === 204) {
+        router.refresh();
+        toast('本を削除しました。');
+      } else {
+        return false;
+      }
+    } catch (error) {
+      return false;
+    }
+  };
+
+  return (
+    <>
+      <Text size="lg" fw={700} ta="center">
+        削除しますか？
+      </Text>
+      <Divider my="lg" />
+      <Text c="dimmed" ta="center">
+        この本を削除すると、メモとログも同時に削除されます。この操作は戻すことができません。
+      </Text>
+      <Space h={30} />
+      <Group justify="center" gap="xl">
+        <Button variant="light" radius="lg" color="gray" onClick={close}>
+          キャンセル
+        </Button>
+        <Button
+          variant="light"
+          radius="lg"
+          color="red"
+          leftSection={<IconTrash size={14} />}
+          onClick={handleDeleteBook}
+        >
+          削除
+        </Button>
+      </Group>
+    </>
+  );
+}

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -7,6 +7,16 @@ export type Book = {
   coverImageUrl: string;
 };
 
+export type BookMenuProps = {
+  bookId: number;
+  uid: string | undefined;
+};
+
+export type DeleteBookModalProps = {
+  params: BookMenuProps;
+  close: () => void;
+};
+
 export type BookProps = {
   book: Book;
 };


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/87

## description
本棚から本を削除できるようにした。表紙を`BackgroundImage`に変え、右上に`BookMenu`を置いてメモと削除を選べるようにしている。これまで表紙全体がメモ画面へのリンクだったが、そのリンクもメニューの「メモ」に移した。

削除を選ぶと`DeleteBookConfirmModal`が開き、`DELETE api/user_books/:bookId`を送る。204が返ったら`router.refresh()`で本棚を更新し、toastを出す。
