### PR TITLE
データ取得の見直し

### DIFF
--- a/src/app/books/[bookId]/memos/page.tsx
+++ b/src/app/books/[bookId]/memos/page.tsx
@@ -115,6 +115,7 @@ function PageContent() {
       }
     } catch (error) {
       toast.error('メモの保存に失敗しました。')
+      return false
     }
   };
 

--- a/src/app/books/[bookId]/memos/page.tsx
+++ b/src/app/books/[bookId]/memos/page.tsx
@@ -17,6 +17,7 @@ import useSWR from 'swr';
 import axios from 'axios';
 import toast from 'react-hot-toast';
 import { MemoParams, BookWithMemo, HandleSaveType } from '@/types/index';
+import MemoLoading from '@/components/loading/MemoLoading';
 
 export default function Page() {
   return (
@@ -120,7 +121,7 @@ function PageContent() {
   };
 
   if (error) return <div>failed to load</div>;
-  if (isLoading) return <div>loading...</div>;
+  if (isLoading) return <div><MemoLoading /></div>;
 
   return (
     <Container my={'md'}>

--- a/src/app/books/[bookId]/memos/page.tsx
+++ b/src/app/books/[bookId]/memos/page.tsx
@@ -114,7 +114,7 @@ function PageContent() {
         return false;
       }
     } catch (error) {
-      return false;
+      toast.error('メモの保存に失敗しました。')
     }
   };
 

--- a/src/app/books/[bookId]/memos/page.tsx
+++ b/src/app/books/[bookId]/memos/page.tsx
@@ -115,13 +115,18 @@ function PageContent() {
         return false;
       }
     } catch (error) {
-      toast.error('メモの保存に失敗しました。')
-      return false
+      toast.error('メモの保存に失敗しました。');
+      return false;
     }
   };
 
   if (error) return <div>failed to load</div>;
-  if (isLoading) return <div><MemoLoading /></div>;
+  if (isLoading)
+    return (
+      <div>
+        <MemoLoading />
+      </div>
+    );
 
   return (
     <Container my={'md'}>

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,9 +1,7 @@
-import { Loader, Center } from '@mantine/core';
+import DefaultLoader from '@/components/loading/DefaultLoader'
 
 export default function Loading() {
   return (
-    <Center style={{ width: '100vw', height: '80vh' }}>
-      <Loader color="blue" type="dots" size="xl" />
-    </Center>
+    <DefaultLoader />
   );
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,7 +1,5 @@
-import DefaultLoader from '@/components/loading/DefaultLoader'
+import DefaultLoader from '@/components/loading/DefaultLoader';
 
 export default function Loading() {
-  return (
-    <DefaultLoader />
-  );
+  return <DefaultLoader />;
 }

--- a/src/components/loading/DefaultLoader.tsx
+++ b/src/components/loading/DefaultLoader.tsx
@@ -1,0 +1,11 @@
+import { Loader, Center } from '@mantine/core';
+
+const DefaultLoader = () => {
+  return (
+    <Center style={{ width: '100vw', height: '80vh' }}>
+      <Loader color="blue" type="dots" size="xl" />
+    </Center>
+  );
+};
+
+export default DefaultLoader;

--- a/src/components/loading/MemoLoading.tsx
+++ b/src/components/loading/MemoLoading.tsx
@@ -1,0 +1,32 @@
+import { Container, Grid, GridCol, Space, Skeleton, Text } from '@mantine/core';
+
+const MemoLoading = () => {
+  return (
+    <Container my={'md'}>
+      <Grid>
+        <GridCol span={3}>
+          <Skeleton radius="lg" w={141} h={200} />
+        </GridCol>
+        <GridCol offset={1} span={6}>
+          <Text size="md" ta={'center'} mb={7}>
+            章
+          </Text>
+          <Skeleton height={50}/>
+        </GridCol>
+      </Grid>
+      <Space h={50} />
+      <Grid>
+        <GridCol span={12}>
+          <Skeleton height={50}/>
+        </GridCol>
+      </Grid>
+      <Grid>
+        <GridCol span={12}>
+          <Skeleton height={200}/>
+        </GridCol>
+      </Grid>
+    </Container>
+  );
+};
+
+export default MemoLoading;

--- a/src/components/loading/MemoLoading.tsx
+++ b/src/components/loading/MemoLoading.tsx
@@ -11,18 +11,18 @@ const MemoLoading = () => {
           <Text size="md" ta={'center'} mb={7}>
             章
           </Text>
-          <Skeleton height={50}/>
+          <Skeleton height={50} />
         </GridCol>
       </Grid>
       <Space h={50} />
       <Grid>
         <GridCol span={12}>
-          <Skeleton height={50}/>
+          <Skeleton height={50} />
         </GridCol>
       </Grid>
       <Grid>
         <GridCol span={12}>
-          <Skeleton height={200}/>
+          <Skeleton height={200} />
         </GridCol>
       </Grid>
     </Container>

--- a/src/components/modal/AddBookConfirmModal.tsx
+++ b/src/components/modal/AddBookConfirmModal.tsx
@@ -48,7 +48,7 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
         return false;
       }
     } catch (error) {
-      toast.error('本の保存に失敗しました。')
+      toast.error('本の保存に失敗しました。');
     }
   };
 

--- a/src/components/modal/AddBookConfirmModal.tsx
+++ b/src/components/modal/AddBookConfirmModal.tsx
@@ -48,7 +48,7 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
         return false;
       }
     } catch (error) {
-      return false;
+      toast.error('本の保存に失敗しました。')
     }
   };
 

--- a/src/components/modal/DeleteBookConfirmModal.tsx
+++ b/src/components/modal/DeleteBookConfirmModal.tsx
@@ -23,7 +23,7 @@ export default function DeleteBookConfirmModal({
         return false;
       }
     } catch (error) {
-      return false;
+      toast.error('本の削除に失敗しました。')
     }
   };
 

--- a/src/components/modal/DeleteBookConfirmModal.tsx
+++ b/src/components/modal/DeleteBookConfirmModal.tsx
@@ -23,7 +23,7 @@ export default function DeleteBookConfirmModal({
         return false;
       }
     } catch (error) {
-      toast.error('本の削除に失敗しました。')
+      toast.error('本の削除に失敗しました。');
     }
   };
 

--- a/src/components/modal/DeleteUserConfirmModal.tsx
+++ b/src/components/modal/DeleteUserConfirmModal.tsx
@@ -17,7 +17,7 @@ export default function DeleteUserConfirmModal({ uid, close }: UserParams) {
         return false;
       }
     } catch (error) {
-      toast.error('退会に失敗しました。')
+      toast.error('退会に失敗しました。');
     }
   };
   return (

--- a/src/components/modal/DeleteUserConfirmModal.tsx
+++ b/src/components/modal/DeleteUserConfirmModal.tsx
@@ -2,6 +2,7 @@ import { Text, Divider, Space, Button, Group } from '@mantine/core';
 import { UserParams } from '@/types/index';
 import axios from 'axios';
 import { handleSignOut } from '@/feature/SignOut';
+import toast from 'react-hot-toast';
 
 export default function DeleteUserConfirmModal({ uid, close }: UserParams) {
   const handleDeleteUser = async () => {
@@ -16,7 +17,7 @@ export default function DeleteUserConfirmModal({ uid, close }: UserParams) {
         return false;
       }
     } catch (error) {
-      return false;
+      toast.error('退会に失敗しました。')
     }
   };
   return (

--- a/src/components/search/SearchForm.tsx
+++ b/src/components/search/SearchForm.tsx
@@ -19,6 +19,7 @@ import axios from 'axios';
 import { SearchFormProps, Item } from '@/types/index';
 import { IconChevronDown } from '@tabler/icons-react';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 
 const SearchForm = ({ onResults }: SearchFormProps) => {
   const theme = useMantineTheme();
@@ -56,7 +57,7 @@ const SearchForm = ({ onResults }: SearchFormProps) => {
       }));
       onResults(books);
     } catch (error) {
-      console.error(error);
+      toast.error('本の検索に失敗しました。')
     }
   };
 

--- a/src/components/search/SearchForm.tsx
+++ b/src/components/search/SearchForm.tsx
@@ -57,7 +57,7 @@ const SearchForm = ({ onResults }: SearchFormProps) => {
       }));
       onResults(books);
     } catch (error) {
-      toast.error('本の検索に失敗しました。')
+      toast.error('本の検索に失敗しました。');
     }
   };
 


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/92

## description
ローディングとエラー表示を見直した。

ローディングは共通の`DefaultLoader`に切り出し、`app/loading.tsx`から使うようにした。メモ画面だけは画面の形に合わせた`MemoLoading`のスケルトンを用意し、`useSWR`の`isLoading`で表示する。

各モーダルでcatchしたまま握りつぶしていたエラーは、toastでメッセージを出すようにした。
