### PR TITLE
お問い合わせフォームを作成

### DIFF
--- a/src/components/footer/Privacy.tsx
+++ b/src/components/footer/Privacy.tsx
@@ -1,103 +1,129 @@
-import { Title, Divider, Space } from '@mantine/core';
+import {
+  Title,
+  Divider,
+  Space,
+  Anchor,
+  Container,
+  Text,
+  List,
+  ListItem,
+} from '@mantine/core';
 
 const Privacy = () => {
   return (
-    <div className="px-8 py-5">
+    <Container my="md">
       <Title size={'h2'} ta={'center'}>
         プライバシーポリシー
       </Title>
       <Space h={20} />
-      <p>
+      <Text>
         Tsundoku（以下、「当方」といいます。）は、本ウェブサイト上で提供するサービス（以下、「本サービス」といいます。）におけるユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下、「本ポリシー」といいます。）を定めます。
-      </p>
+      </Text>
       <Space h={30} />
       <Title size={'h3'}>お客様から取得する情報</Title>
       <Divider my={'sm'} />
-      <p>当方は、お客様から以下の情報を取得します。</p>
-      <ul className="pl-5">
-        <li>氏名(ニックネームやペンネームも含む)</li>
-        <li>メールアドレス</li>
-        <li>写真や動画</li>
-        <li>
+      <Text>当方は、お客様から以下の情報を取得します。</Text>
+      <List withPadding>
+        <ListItem>氏名(ニックネームやペンネームも含む)</ListItem>
+        <ListItem>メールアドレス</ListItem>
+        <ListItem>写真や動画</ListItem>
+        <ListItem>
           外部サービスでお客様が利用するID、その他外部サービスのプライバシー設定によりお客様が連携先に開示を認めた情報
-        </li>
-        <li>Cookie(クッキー)を用いて生成された識別情報</li>
-        <li>OSが生成するID、端末の種類、端末識別子等のOSや端末に関する情報</li>
-        <li>
+        </ListItem>
+        <ListItem>Cookie(クッキー)を用いて生成された識別情報</ListItem>
+        <ListItem>
+          OSが生成するID、端末の種類、端末識別子等のOSや端末に関する情報
+        </ListItem>
+        <ListItem>
           本サービスの滞在時間、入力履歴、購買履歴等の本サービスにおけるお客様の行動履歴
-        </li>
-        <li>
+        </ListItem>
+        <ListItem>
           本サービスの起動時間、入力履歴、購買履歴等の本サービスの利用履歴
-        </li>
-      </ul>
+        </ListItem>
+      </List>
+      <Space h={30} />
       <Title size={'h3'}>お客様の情報を利用する目的</Title>
       <Divider my={'sm'} />
-      <p>当方は、お客様から取得した情報を、以下の目的のために利用します。</p>
-      <ul className="pl-5">
-        <li>本サービスに関する登録の受付、お客様の本人確認、認証のため</li>
-        <li>お客様の本サービスの利用履歴を管理するため</li>
-        <li>
+      <Text>
+        当方は、お客様から取得した情報を、以下の目的のために利用します。
+      </Text>
+      <List withPadding>
+        <ListItem>
+          本サービスに関する登録の受付、お客様の本人確認、認証のため
+        </ListItem>
+        <ListItem>お客様の本サービスの利用履歴を管理するため</ListItem>
+        <ListItem>
           本サービスにおけるお客様の行動履歴を分析し、本サービスの維持改善に役立てるため
-        </li>
-        <li>本サービスに関するご案内をするため</li>
-        <li>お客様からのお問い合わせに対応するため</li>
-        <li>当方の規約や法令に違反する行為に対応するため</li>
-        <li>本サービスの変更、提供中止、終了、契約解除をご連絡するため</li>
-        <li>当方規約の変更等を通知するため</li>
-        <li>以上の他、本サービスの提供、維持、保護及び改善のため</li>
-      </ul>
+        </ListItem>
+        <ListItem>本サービスに関するご案内をするため</ListItem>
+        <ListItem>お客様からのお問い合わせに対応するため</ListItem>
+        <ListItem>当方の規約や法令に違反する行為に対応するため</ListItem>
+        <ListItem>
+          本サービスの変更、提供中止、終了、契約解除をご連絡するため
+        </ListItem>
+        <ListItem>当方規約の変更等を通知するため</ListItem>
+        <ListItem>
+          以上の他、本サービスの提供、維持、保護及び改善のため
+        </ListItem>
+      </List>
+      <Space h={30} />
       <Title size={'h3'}>安全管理のために講じた措置</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         当方が、お客様から取得した情報に関して安全管理のために講じた措置につきましては、末尾記載のお問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。
-      </p>
+      </Text>
       <Space h={30} />
       <Title size={'h3'}>第三者提供</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         当方は、お客様から取得する情報のうち、個人データ（個人情報保護法第２条第６項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。
         但し、次の場合は除きます。
-      </p>
-      <ul className="pl-5">
-        <li>個人データの取扱いを外部に委託する場合</li>
-        <li>当方や本サービスが買収された場合</li>
-        <li>
+      </Text>
+      <List withPadding>
+        <ListItem>個人データの取扱いを外部に委託する場合</ListItem>
+        <ListItem>当方や本サービスが買収された場合</ListItem>
+        <ListItem>
           事業パートナーと共同利用する場合（具体的な共同利用がある場合は、その内容を別途公表します。）
-        </li>
-        <li>その他、法律によって合法的に第三者提供が許されている場合</li>
-      </ul>
+        </ListItem>
+        <ListItem>
+          その他、法律によって合法的に第三者提供が許されている場合
+        </ListItem>
+      </List>
+      <Space h={30} />
       <Title size={'h3'}>アクセス解析ツール</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         当方は、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。Googleアナリティクスについて、詳しくは
-        <a
+        <Anchor
           href="https://marketingplatform.google.com/about/analytics/terms/jp/"
           target="_blank"
           rel="noreferrer"
         >
           こちら
-        </a>
+        </Anchor>
         からご確認ください。
-      </p>
+      </Text>
       <Space h={30} />
       <Title size={'h3'}>プライバシーポリシーの変更</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         当方は、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。
-      </p>
-      <Space h={60} />
+      </Text>
+      <Space h={30} />
       <Title size={'h3'}>お問い合わせ</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、以下のお問い合わせフォームにご連絡ください。
-      </p>
-      <p>
-        <a href="">お問い合わせフォーム</a>
-      </p>
-      <br />
-      <p>以上</p>
-      <p>2024年7月12日制定</p>
-    </div>
+      </Text>
+      <Text>
+        <Anchor href="https://forms.gle/1eFj51KwQCQLR6vd8">
+          お問い合わせフォーム
+        </Anchor>
+      </Text>
+      <Space h={20} />
+      <Text>以上</Text>
+      <Text>2024年7月12日制定</Text>
+    </Container>
   );
 };
 

--- a/src/components/footer/terms.tsx
+++ b/src/components/footer/terms.tsx
@@ -1,212 +1,240 @@
-import { Title, Divider, Space } from '@mantine/core';
+import {
+  Title,
+  Divider,
+  Space,
+  Container,
+  Text,
+  List,
+  ListItem,
+} from '@mantine/core';
 import Link from 'next/link';
 
 const Terms = () => {
   return (
-    <div className="px-8 py-5">
+    <Container my="md">
       <Title size={'h2'} ta={'center'}>
         利用規約
       </Title>
       <Space h={20} />
-      <p>
+      <Text>
         この利用規約（以下、「本規約」といいます。）は、Tsundokuの管理者（以下、「当方」といいます。）がこのウェブサイト上で提供するサービス（以下、「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下、「ユーザー」といいます。）には、本規約に従って、本サービスをご利用いただきます。
-      </p>
+      </Text>
       <Space h={30} />
       <Title size={'h3'}>第1条（適用）</Title>
       <Divider my={'sm'} />
-      <ol className="pl-5">
-        <li>
+      <List type="ordered">
+        <ListItem>
           本規約は、ユーザーと当方との間の本サービスの利用に関わる一切の関係に適用されるものとします。
-        </li>
-        <li>
+        </ListItem>
+        <ListItem>
           当方は本サービスに関し、本規約のほか、ご利用にあたってのルール等、各種の定め（以下、「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず、本規約の一部を構成するものとします。
-        </li>
-        <li>
+        </ListItem>
+        <ListItem>
           本規約の規定が前条の個別規定の規定と矛盾する場合には、個別規定において特段の定めなき限り、個別規定の規定が優先されるものとします。
-        </li>
-      </ol>
+        </ListItem>
+      </List>
       <Space h={30} />
       <Title size={'h3'}>第2条（利用登録）</Title>
       <Divider my={'sm'} />
-      <ol className="pl-5">
-        <li>
+      <List type="ordered">
+        <ListItem>
           本サービスにおいては、登録希望者が本規約に同意の上、当方の定める方法によって利用登録を申請し、当方がこれを承認することによって、利用登録が完了するものとします。
-        </li>
-        <li>
+        </ListItem>
+        <ListItem>
           当方は、利用登録の申請者に以下の事由があると判断した場合、利用登録の申請を承認しないことがあり、その理由については一切の開示義務を負わないものとします。
-          <ol className="pl-5">
-            <li>利用登録の申請に際して虚偽の事項を届け出た場合</li>
-            <li>本規約に違反したことがある者からの申請である場合</li>
-            <li>その他、当方が利用登録を相当でないと判断した場合</li>
-          </ol>
-        </li>
-      </ol>
+          <List type="ordered">
+            <ListItem>利用登録の申請に際して虚偽の事項を届け出た場合</ListItem>
+            <ListItem>
+              本規約に違反したことがある者からの申請である場合
+            </ListItem>
+            <ListItem>
+              その他、当方が利用登録を相当でないと判断した場合
+            </ListItem>
+          </List>
+        </ListItem>
+      </List>
       <Space h={30} />
       <Title size={'h3'}>第3条（ユーザーIDおよびパスワードの管理）</Title>
       <Divider my={'sm'} />
-      <ol className="pl-5">
-        <li>
+      <List type="ordered">
+        <ListItem>
           ユーザーは、自己の責任において、本サービスのユーザーIDおよびパスワードを適切に管理するものとします。
-        </li>
-        <li>
+        </ListItem>
+        <ListItem>
           ユーザーは、いかなる場合にも、ユーザーIDおよびパスワードを第三者に譲渡または貸与し、もしくは第三者と共用することはできません。当方は、ユーザーIDとパスワードの組み合わせが登録情報と一致してログインされた場合には、そのユーザーIDを登録しているユーザー自身による利用とみなします。
-        </li>
-        <li>
+        </ListItem>
+        <ListItem>
           ユーザーID及びパスワードが第三者によって使用されたことによって生じた損害は、当方に故意又は重大な過失がある場合を除き、当方は一切の責任を負わないものとします。
-        </li>
-      </ol>
+        </ListItem>
+      </List>
       <Space h={30} />
       <Title size={'h3'}>第4条（禁止事項）</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。
-      </p>
-      <ol className="pl-5">
-        <li>法令または公序良俗に違反する行為</li>
-        <li>犯罪行為に関連する行為</li>
-        <li>
+      </Text>
+      <List type="ordered">
+        <ListItem>法令または公序良俗に違反する行為</ListItem>
+        <ListItem>犯罪行為に関連する行為</ListItem>
+        <ListItem>
           当方、本サービスの他のユーザー、または第三者のサーバーまたはネットワークの機能を破壊したり、妨害したりする行為
-        </li>
-        <li>本サービスの運営を妨害するおそれのある行為</li>
-        <li>他のユーザーに関する個人情報等を収集または蓄積する行為</li>
-        <li>不正アクセスをし、またはこれを試みる行為</li>
-        <li>他のユーザーに成りすます行為</li>
-        <li>
+        </ListItem>
+        <ListItem>本サービスの運営を妨害するおそれのある行為</ListItem>
+        <ListItem>
+          他のユーザーに関する個人情報等を収集または蓄積する行為
+        </ListItem>
+        <ListItem>不正アクセスをし、またはこれを試みる行為</ListItem>
+        <ListItem>他のユーザーに成りすます行為</ListItem>
+        <ListItem>
           本サービスに関連して、反社会的勢力に対して直接または間接に利益を供与する行為
-        </li>
-        <li>
+        </ListItem>
+        <ListItem>
           当方、本サービスの他のユーザーまたは第三者の知的財産権、肖像権、プライバシー、名誉その他の権利または利益を侵害する行為
-        </li>
-        <li>
+        </ListItem>
+        <ListItem>
           以下の表現を含み、または含むと当方が判断する内容を本サービス上に投稿し、または送信する行為
-          <ol className="pl-5">
-            <li>過度に暴力的な表現</li>
-            <li>露骨な性的表現</li>
-            <li>
+          <List type="ordered">
+            <ListItem>過度に暴力的な表現</ListItem>
+            <ListItem>露骨な性的表現</ListItem>
+            <ListItem>
               人種、国籍、信条、性別、社会的身分、門地等による差別につながる表現
-            </li>
-            <li>自殺、自傷行為、薬物乱用を誘引または助長する表現</li>
-            <li>その他反社会的な内容を含み他人に不快感を与える表現</li>
-          </ol>
-        </li>
-        <li>宗教活動または宗教団体への勧誘行為</li>
-        <li>その他、当方が不適切であると判断する行為</li>
-      </ol>
+            </ListItem>
+            <ListItem>
+              自殺、自傷行為、薬物乱用を誘引または助長する表現
+            </ListItem>
+            <ListItem>
+              その他反社会的な内容を含み他人に不快感を与える表現
+            </ListItem>
+          </List>
+        </ListItem>
+        <ListItem>宗教活動または宗教団体への勧誘行為</ListItem>
+        <ListItem>その他、当方が不適切であると判断する行為</ListItem>
+      </List>
       <Space h={30} />
       <Title size={'h3'}>第5条（本サービスの提供の停止等）</Title>
       <Divider my={'sm'} />
-      <ol className="pl-5">
-        <li>
+      <List type="ordered">
+        <ListItem>
           当方は、以下のいずれかの事由があると判断した場合、ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
-          <ol className="pl-5">
-            <li>
+          <List type="ordered">
+            <ListItem>
               本サービスにかかるコンピュータシステムの保守点検または更新を行う場合
-            </li>
-            <li>
+            </ListItem>
+            <ListItem>
               地震、落雷、火災、停電または天災などの不可抗力により、本サービスの提供が困難となった場合
-            </li>
-            <li>コンピュータまたは通信回線等が事故により停止した場合</li>
-            <li>その他、当方が本サービスの提供が困難と判断した場合</li>
-          </ol>
-        </li>
-        <li>
+            </ListItem>
+            <ListItem>
+              コンピュータまたは通信回線等が事故により停止した場合
+            </ListItem>
+            <ListItem>
+              その他、当方が本サービスの提供が困難と判断した場合
+            </ListItem>
+          </List>
+        </ListItem>
+        <ListItem>
           当方は、本サービスの提供の停止または中断により、ユーザーまたは第三者が被ったいかなる不利益または損害についても、一切の責任を負わないものとします。
-        </li>
-      </ol>
+        </ListItem>
+      </List>
       <Space h={30} />
       <Title size={'h3'}>第6条（利用制限および登録抹消）</Title>
       <Divider my={'sm'} />
-      <ol className="pl-5">
-        <li>
+      <List type="ordered">
+        <ListItem>
           当方は、ユーザーが以下のいずれかに該当する場合には、事前の通知なく、ユーザーに対して、本サービスの全部もしくは一部の利用を制限し、またはユーザーとしての登録を抹消することができるものとします。
-          <ol className="pl-5">
-            <li>本規約のいずれかの条項に違反した場合</li>
-            <li>登録事項に虚偽の事実があることが判明した場合</li>
-            <li>当方からの連絡に対し、一定期間返答がない場合</li>
-            <li>本サービスについて、最終の利用から一定期間利用がない場合</li>
-            <li>その他、当方が本サービスの利用を適当でないと判断した場合</li>
-          </ol>
-        </li>
-        <li>
+          <List type="ordered">
+            <ListItem>本規約のいずれかの条項に違反した場合</ListItem>
+            <ListItem>登録事項に虚偽の事実があることが判明した場合</ListItem>
+            <ListItem>当方からの連絡に対し、一定期間返答がない場合</ListItem>
+            <ListItem>
+              本サービスについて、最終の利用から一定期間利用がない場合
+            </ListItem>
+            <ListItem>
+              その他、当方が本サービスの利用を適当でないと判断した場合
+            </ListItem>
+          </List>
+        </ListItem>
+        <ListItem>
           当方は、本条に基づき当方が行った行為によりユーザーに生じた損害について、一切の責任を負いません。
-        </li>
-      </ol>
+        </ListItem>
+      </List>
       <Space h={30} />
       <Title size={'h3'}>第7条（退会）</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         ユーザーは、当方の定める退会手続により、本サービスから退会できるものとします。
-      </p>
+      </Text>
       <Space h={30} />
       <Title size={'h3'}>第8条（保証の否認および免責事項）</Title>
       <Divider my={'sm'} />
-      <ol className="pl-5">
-        <li>
+      <List type="ordered">
+        <ListItem>
           当方は、本サービスに事実上または法律上の瑕疵(安全性、信頼性、正確性、完全性、有効性、特定の目的への適合性、セキュリティなどに関する欠陥、エラーやバグ、権利侵害などを含みます。)がないことを明示的にも黙示的にも保証しておりません。当方は、ユーザーに対して、かかる瑕疵を除去して本サービスを提供する義務を負いません。
-        </li>
-        <li>
+        </ListItem>
+        <ListItem>
           当方は、本サービスに起因してユーザーに生じたあらゆる損害について、当方の故意又は重過失による場合を除き、一切の責任を負いません。
-        </li>
-        <li>
+        </ListItem>
+        <ListItem>
           当方は、本サービスに関して、ユーザーと他のユーザーまたは第三者との間において生じた取引、連絡または紛争等について一切責任を負いません。
-        </li>
-      </ol>
+        </ListItem>
+      </List>
       <Space h={30} />
       <Title size={'h3'}>第9条（サービス内容の変更等）</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         当方は、ユーザーへの事前の告知をもって、本サービスの内容を変更、追加または廃止することがあり、ユーザーはこれを承諾するものとします。
-      </p>
+      </Text>
       <Space h={30} />
       <Title size={'h3'}>第10条（利用規約の変更）</Title>
       <Divider my={'sm'} />
-      <ol className="pl-5">
-        <li>
+      <List type="ordered">
+        <ListItem>
           当方は以下の場合には、ユーザーの個別の同意を要せず、本規約を変更することができるものとします。
-          <ol className="pl-5">
-            <li>本規約の変更がユーザーの一般の利益に適合するとき</li>
-            <li>
+          <List type="ordered">
+            <ListItem>
+              本規約の変更がユーザーの一般の利益に適合するとき
+            </ListItem>
+            <ListItem>
               本規約の変更が本サービス利用契約の目的に反せず、かつ、変更の必要性、変更後の内容の相当性その他の変更に係る事情に照らして合理的なものであるとき
-            </li>
-          </ol>
-        </li>
-        <li>
+            </ListItem>
+          </List>
+        </ListItem>
+        <ListItem>
           当方はユーザーに対し、前項による本規約の変更にあたり、事前に本規約を変更する旨及び変更後の本規約の内容並びにその効力発生時期を通知します。
-        </li>
-      </ol>
+        </ListItem>
+      </List>
       <Space h={30} />
       <Title size={'h3'}>第11条（個人情報の取り扱い）</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         当方は、本サービスの利用によって取得する個人情報については、
         <Link href={'/privacy'}>当方プライバシーポリシー</Link>
         に従い適切に取り扱うものとします。
-      </p>
+      </Text>
       <Space h={30} />
       <Title size={'h3'}>第12条（通知または連絡）</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         ユーザーと当方との間の通知または連絡は，当方の定める方法によって行うものとします。当方は、ユーザーから、当方が別途定める方式に従った変更届け出がない限り、現在登録されている連絡先が有効なものとみなして当該連絡先へ通知または連絡を行い、これらは、発信時にユーザーへ到達したものとみなします。
-      </p>
+      </Text>
       <Space h={30} />
       <Title size={'h3'}>第13条（権利義務の譲渡の禁止）</Title>
       <Divider my={'sm'} />
-      <p>
+      <Text>
         ユーザーは、当方の書面による事前の承諾なく、利用契約上の地位または本規約に基づく権利もしくは義務を第三者に譲渡し、または担保に供することはできません。
-      </p>
+      </Text>
       <Space h={30} />
       <Title size={'h3'}>第14条（準拠法・裁判管轄）</Title>
       <Divider my={'sm'} />
-      <ol className="pl-5">
-        <li>本規約の解釈にあたっては、日本法を準拠法とします。</li>
-        <li>
+      <List type="ordered">
+        <ListItem>本規約の解釈にあたっては、日本法を準拠法とします。</ListItem>
+        <ListItem>
           本サービスに関して紛争が生じた場合には、当方の所在地を管轄する裁判所を専属的合意管轄とします。
-        </li>
-      </ol>
+        </ListItem>
+      </List>
       <Space h={30} />
-      <p>以上</p>
-      <p>2024年7月12日制定</p>
-    </div>
+      <Text>以上</Text>
+      <Text>2024年7月12日制定</Text>
+    </Container>
   );
 };
 


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/85

## description
Googleフォームで作成した問い合わせフォームへのリンクを、プライバシーポリシーのページに追加した。

あわせて利用規約とプライバシーポリシーの見た目を整え、素のHTMLタグで書いていた本文をMantineの`Container`・`Text`・`List`に置き換えている。
