### PR TITLE
SessionにhandleNameを追加

### DIFF
--- a/src/app/books/[bookId]/memos/page.tsx
+++ b/src/app/books/[bookId]/memos/page.tsx
@@ -33,7 +33,7 @@ function PageContent() {
   const apiMemoUrl = `http://localhost:3001/api/books/${bookId}/memos`;
   const { data: session, status } = useSession();
   const params = {
-    uid: session?.user?.id,
+    id: session?.user?.id,
     bookId: bookId,
   };
   const [bookWithMemos, setBookWithMemos] = useState<BookWithMemo>();

--- a/src/app/books/[bookId]/memos/page.tsx
+++ b/src/app/books/[bookId]/memos/page.tsx
@@ -33,7 +33,7 @@ function PageContent() {
   const apiMemoUrl = `http://localhost:3001/api/books/${bookId}/memos`;
   const { data: session, status } = useSession();
   const params = {
-    id: session?.user?.id,
+    userId: session?.user?.id,
     bookId: bookId,
   };
   const [bookWithMemos, setBookWithMemos] = useState<BookWithMemo>();
@@ -69,11 +69,13 @@ function PageContent() {
       const headingRes = await axios.patch(
         `http://localhost:3001/api/headings/${headingId}`,
         {
+          userId: session?.user?.id,
           id: headingId,
           title: title,
         },
       );
       const memoRes = await axios.patch(`${apiMemoUrl}/${memoId}`, {
+        userId: session?.user.id,
         memo: {
           id: memoId,
           body: content,
@@ -82,6 +84,7 @@ function PageContent() {
       const logRes = await axios.post(
         'http://localhost:3001/api/reading_logs',
         {
+          userId: session?.user.id,
           memoId: memoId,
         },
       );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,13 @@
 import { auth } from '#auth';
 import TopPage from '@/components/top/TopPage';
 import AuthenticatedTopPage from '@/components/top/AuthenticatedTopPage';
+import Welcome from '@/components/top/Welcome';
 
 export default async function Home() {
   const session = await auth();
-  if (session?.user) {
+  if (session?.user.handleName.includes('User')) {
+    return <Welcome />;
+  } else if (session?.user) {
     return <AuthenticatedTopPage />;
   } else {
     return <TopPage />;

--- a/src/app/users/[handleName]/bookshelf/edit/page.tsx
+++ b/src/app/users/[handleName]/bookshelf/edit/page.tsx
@@ -8,7 +8,7 @@ const Page = async () => {
   const session = await auth();
 
   const getBooks = async () => {
-    const params = { id: session?.user?.id };
+    const params = { userId: session?.user?.id };
     const res = await axios.get('http://localhost:3001/api/books', { params });
     return res.data.map((book: BookResponse) => ({
       id: book.id,

--- a/src/app/users/[handleName]/bookshelf/edit/page.tsx
+++ b/src/app/users/[handleName]/bookshelf/edit/page.tsx
@@ -8,7 +8,7 @@ const Page = async () => {
   const session = await auth();
 
   const getBooks = async () => {
-    const params = { uid: session?.user?.id };
+    const params = { id: session?.user?.id };
     const res = await axios.get('http://localhost:3001/api/books', { params });
     return res.data.map((book: BookResponse) => ({
       id: book.id,
@@ -25,7 +25,7 @@ const Page = async () => {
         {session?.user?.name}さんの本棚
       </Title>
       <Space h={30} />
-      <DndList bookItems={bookItems} uid={session?.user?.id} />
+      <DndList bookItems={bookItems} id={session?.user?.id} />
     </Container>
   );
 };

--- a/src/app/users/[handleName]/page.tsx
+++ b/src/app/users/[handleName]/page.tsx
@@ -12,7 +12,7 @@ import { UserParams } from '@/types/index';
 
 export default function Page() {
   const dynamicParams = useParams();
-  const params = { uid: dynamicParams.id };
+  const params = { handleName: dynamicParams.handleName };
   const apiUrl = `http://localhost:3001/api/users/${dynamicParams.id}`;
   const [bookItems, setBookItems] = useState<Book[]>([]);
   const [readingLogs, setReadingLogs] = useState<Log[]>([]);

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>welcome</p>;
+}

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,3 +1,0 @@
-export default function Page() {
-  return <p>welcome</p>;
-}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,20 +1,50 @@
-import NextAuth from 'next-auth';
+import NextAuth, { type DefaultSession } from 'next-auth';
 import Google from 'next-auth/providers/google';
 import axios from 'axios';
 import { NextResponse } from 'next/server';
 
+declare module 'next-auth' {
+  interface Session extends DefaultSession {
+    user: {
+      handleName: string;
+    } & DefaultSession['user'];
+  }
+}
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [Google],
   callbacks: {
-    async jwt({ token, profile }) {
+    async jwt({ token, profile, trigger, session }) {
+      if (!token.handleName || !token.id) {
+        try {
+          const res = await axios.get(
+            'http://localhost:3001/api/auth/add_session_user_data',
+            {
+              params: { email: token.email },
+            },
+          );
+          if (res.status === 200) {
+            token.id = res.data.id;
+            token.handleName = res.data.handle_name;
+          }
+        } catch (error) {
+          console.warn(error);
+        }
+      }
       if (profile) {
         token.sub = profile.sub || undefined;
+      }
+      if (trigger === 'update') {
+        token.handleName = session.user.handleName;
       }
       return token;
     },
     async session({ session, token }) {
-      if (token.sub) {
-        session.user.id = token.sub;
+      if (token.id) {
+        session.user.id = token.id as string;
+      }
+      if (token.handleName) {
+        session.user.handleName = token.handleName as string;
       }
       return session;
     },
@@ -34,10 +64,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             uid,
           },
         );
-        if (res.status === 200) {
+        if (res.status === 200 || res.status === 201) {
           return true;
-        } else if (res.status === 204) {
-          return 'http://localhost:3000/welcome';
         } else {
           return false;
         }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -36,6 +36,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         );
         if (res.status === 200) {
           return true;
+        } else if (res.status === 204) {
+          return 'http://localhost:3000/welcome';
         } else {
           return false;
         }

--- a/src/components/Cal/Cal.tsx
+++ b/src/components/Cal/Cal.tsx
@@ -4,7 +4,7 @@ import { auth } from '@/auth';
 
 export default async function Cal() {
   const session = await auth();
-  const params = { id: session?.user?.id };
+  const params = { userId: session?.user?.id };
   const res = await axios.get('http://localhost:3001/api/reading_logs', {
     params,
   });

--- a/src/components/Cal/Cal.tsx
+++ b/src/components/Cal/Cal.tsx
@@ -4,7 +4,7 @@ import { auth } from '@/auth';
 
 export default async function Cal() {
   const session = await auth();
-  const params = { uid: session?.user?.id };
+  const params = { id: session?.user?.id };
   const res = await axios.get('http://localhost:3001/api/reading_logs', {
     params,
   });

--- a/src/components/bookshelf/AuthenticatedBookItems.tsx
+++ b/src/components/bookshelf/AuthenticatedBookItems.tsx
@@ -6,7 +6,7 @@ import { BookResponse } from '@/types/index';
 const AuthenticatedBookItems = async () => {
   const getBooks = async () => {
     const session = await auth();
-    const params = { id: session?.user?.id };
+    const params = { userId: session?.user?.id };
     const res = await axios.get('http://localhost:3001/api/books', { params });
     return res.data.map((book: BookResponse) => ({
       id: book.id,

--- a/src/components/bookshelf/AuthenticatedBookItems.tsx
+++ b/src/components/bookshelf/AuthenticatedBookItems.tsx
@@ -6,7 +6,7 @@ import { BookResponse } from '@/types/index';
 const AuthenticatedBookItems = async () => {
   const getBooks = async () => {
     const session = await auth();
-    const params = { uid: session?.user?.id };
+    const params = { id: session?.user?.id };
     const res = await axios.get('http://localhost:3001/api/books', { params });
     return res.data.map((book: BookResponse) => ({
       id: book.id,

--- a/src/components/bookshelf/BookItem.tsx
+++ b/src/components/bookshelf/BookItem.tsx
@@ -3,6 +3,7 @@
 import { Image } from '@mantine/core';
 import { useSession, SessionProvider } from 'next-auth/react';
 import { BookProps } from '@/types/index';
+import Link from 'next/link';
 
 const BookItemContent = ({ book }: BookProps) => {
   const { data: session } = useSession();
@@ -10,13 +11,15 @@ const BookItemContent = ({ book }: BookProps) => {
   return (
     <>
       {session ? (
-        <Image
-          radius="md"
-          w={141}
-          h={200}
-          src={book.coverImageUrl}
-          alt={book.title}
-        />
+        <Link href={`/books/${book.id}/memos`}>
+          <Image
+            radius="md"
+            w={141}
+            h={200}
+            src={book.coverImageUrl}
+            alt={book.title}
+          />
+        </Link>
       ) : (
         <Image
           radius="md"

--- a/src/components/bookshelf/BookMenu.tsx
+++ b/src/components/bookshelf/BookMenu.tsx
@@ -14,7 +14,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { Modal } from '@mantine/core';
 import DeleteBookConfirmModal from '../modal/DeleteBookConfirmModal';
 
-export default function BookMenu({ bookId, uid }: BookMenuProps) {
+export default function BookMenu({ bookId, id }: BookMenuProps) {
   const [opened, { open, close }] = useDisclosure(false);
 
   return (
@@ -27,7 +27,7 @@ export default function BookMenu({ bookId, uid }: BookMenuProps) {
         centered
       >
         <DeleteBookConfirmModal
-          params={{ bookId: bookId, uid: uid }}
+          params={{ bookId: bookId, id: id }}
           close={close}
         />
       </Modal>

--- a/src/components/bookshelf/DndList.tsx
+++ b/src/components/bookshelf/DndList.tsx
@@ -18,13 +18,13 @@ import DeleteBookConfirmModal from '../modal/DeleteBookConfirmModal';
 import toast from 'react-hot-toast';
 import { useState } from 'react';
 
-export function DndList({ bookItems, uid }: BookItemsProps) {
+export function DndList({ bookItems, id }: BookItemsProps) {
   const [source, setSource] = useState<number>(0);
   const [state, stateHandlers] = useListState(bookItems);
   const [deleteParamsState, setDeleteParamsState] = useSetState({
     bookId: 0,
     position: 0,
-    uid: uid,
+    id: id,
   });
   const [opened, { open, close }] = useDisclosure(false);
 
@@ -55,7 +55,7 @@ export function DndList({ bookItems, uid }: BookItemsProps) {
     const params = {
       bookId: book?.id,
       destinationBookId: destinationBook?.id,
-      uid: uid,
+      id: id,
     };
     try {
       const res = await axios.post(

--- a/src/components/button/DeleteAccountButton.tsx
+++ b/src/components/button/DeleteAccountButton.tsx
@@ -5,7 +5,7 @@ import { UserParams } from '@/types/index';
 import DeleteUserConfirmModal from '../modal/DeleteUserConfirmModal';
 import { useDisclosure } from '@mantine/hooks';
 
-export default function DeleteAccountButton({ uid }: UserParams) {
+export default function DeleteAccountButton({ id }: UserParams) {
   const [opened, { open, close }] = useDisclosure(false);
 
   return (
@@ -17,7 +17,7 @@ export default function DeleteAccountButton({ uid }: UserParams) {
         withCloseButton={false}
         centered
       >
-        <DeleteUserConfirmModal uid={uid} close={close} />
+        <DeleteUserConfirmModal id={id} close={close} />
       </Modal>
       <Button variant="light" radius="lg" color="red" onClick={open}>
         アカウントを削除

--- a/src/components/confirm/ConfirmDeletion.tsx
+++ b/src/components/confirm/ConfirmDeletion.tsx
@@ -40,7 +40,7 @@ export default async function ConfirmDeletion() {
       </Alert>
       <Space h={30} />
       <Center>
-        <DeleteAccountButton uid={session?.user?.id} />
+        <DeleteAccountButton id={session?.user?.id} />
       </Center>
     </Container>
   );

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -22,7 +22,7 @@ export async function Header() {
           <Group ml="xl" gap={0}>
             {session?.user && (
               <UserMenu
-                name={session.user.name!}
+                handleName={session.user.handleName!}
                 image={session.user.image!}
                 id={session.user.id!}
               />

--- a/src/components/header/UserMenu.tsx
+++ b/src/components/header/UserMenu.tsx
@@ -18,12 +18,12 @@ import { UserInfo } from '@/types/index';
 import Link from 'next/link';
 import { useClipboard } from '@mantine/hooks';
 
-export default function UserMenu({ name, image, id }: UserInfo) {
+export default function UserMenu({ handleName, image, id }: UserInfo) {
   const [userMenuOpened, setUserMenuOpened] = useState(false);
   const clipboard = useClipboard();
 
   const handleCopyUrl = () => {
-    const url = `http://localhost:3000/users/${id}`;
+    const url = `http://localhost:3000/users/${handleName}`;
     clipboard.copy(url);
 
     if (!clipboard.error) {
@@ -49,9 +49,9 @@ export default function UserMenu({ name, image, id }: UserInfo) {
           })}
         >
           <Group gap={7}>
-            <Avatar src={image} alt={name} radius="xl" size={20} />
+            <Avatar src={image} alt={handleName} radius="xl" size={20} />
             <Text fw={500} size="sm" lh={1} mr={3}>
-              {name}
+              {handleName}
             </Text>
             <IconChevronDown
               style={{ width: rem(12), height: rem(12) }}

--- a/src/components/modal/AddBookConfirmModal.tsx
+++ b/src/components/modal/AddBookConfirmModal.tsx
@@ -29,7 +29,7 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
     const title = book.title;
     const author = book.author;
     const coverImageUrl = book.coverImageUrl;
-    const uid = session?.user?.id;
+    const id = session?.user?.id;
     const headingNumber = value;
 
     try {
@@ -37,7 +37,7 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
         title,
         author,
         coverImageUrl,
-        uid,
+        id,
         headingNumber,
       });
       if (res.status === 200) {

--- a/src/components/modal/DeleteUserConfirmModal.tsx
+++ b/src/components/modal/DeleteUserConfirmModal.tsx
@@ -6,7 +6,7 @@ import toast from 'react-hot-toast';
 
 export default function DeleteUserConfirmModal({ id, close }: UserParams) {
   const handleDeleteUser = async () => {
-    const params = { id: id };
+    const params = { userId: id };
     try {
       const res = await axios.delete(`http://localhost:3001/api/users/${id}`, {
         params,

--- a/src/components/modal/DeleteUserConfirmModal.tsx
+++ b/src/components/modal/DeleteUserConfirmModal.tsx
@@ -4,11 +4,11 @@ import axios from 'axios';
 import { handleSignOut } from '@/feature/SignOut';
 import toast from 'react-hot-toast';
 
-export default function DeleteUserConfirmModal({ uid, close }: UserParams) {
+export default function DeleteUserConfirmModal({ id, close }: UserParams) {
   const handleDeleteUser = async () => {
-    const params = { uid: uid };
+    const params = { id: id };
     try {
-      const res = await axios.delete(`http://localhost:3001/api/users/${uid}`, {
+      const res = await axios.delete(`http://localhost:3001/api/users/${id}`, {
         params,
       });
       if (res.status === 204) {

--- a/src/components/top/Welcome.tsx
+++ b/src/components/top/Welcome.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import {
+  Container,
+  Grid,
+  GridCol,
+  TextInput,
+  Flex,
+  Button,
+  Title,
+  Text,
+  Space,
+} from '@mantine/core';
+import { useState } from 'react';
+import { useSession, SessionProvider } from 'next-auth/react';
+import axios from 'axios';
+import toast from 'react-hot-toast';
+import { useRouter } from 'next/navigation';
+
+export default function Welcome() {
+  return (
+    <SessionProvider>
+      <PageContent />
+    </SessionProvider>
+  );
+}
+
+function PageContent() {
+  const { data: session, update } = useSession();
+  const [value, setValue] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async () => {
+    if (value.includes('User')) {
+      toast.error('Userが含まれています。');
+      return;
+    }
+    try {
+      const res = await axios.patch(
+        `http://localhost:3001/api/users/${session?.user?.id}`,
+        {
+          handle_name: value,
+        },
+      );
+      if (res.status === 200) {
+        await update({ user: { handleName: value } });
+        router.refresh();
+        toast.success('設定しました！');
+      } else {
+        return false;
+      }
+    } catch (error) {
+      if (
+        axios.isAxiosError(error) &&
+        error.response?.data.error === 'Handle name has already been taken'
+      ) {
+        toast.error(`${value}はすでに使われています。`);
+        return false;
+      } else {
+        toast.error('更新に失敗しました。');
+        return false;
+      }
+    }
+  };
+
+  return (
+    <Container my="md">
+      <Title size={'h2'} ta="center">
+        ハンドルネーム登録
+      </Title>
+      <Space h={20} />
+      <Text ta="center">ハンドルネームを決めましょう！</Text>
+      <Text ta="center">
+        例 : https://tsundoku.com/
+        <Text span fw={700}>
+          dokusyo
+        </Text>
+      </Text>
+      <Text ta="center">
+        ※サービスの都合上、{' '}
+        <Text span fw={700}>
+          User
+        </Text>
+        という単語は含まないようにお願いします。
+      </Text>
+      <Space h={20} />
+      <Grid>
+        <GridCol span={6} offset={3}>
+          <TextInput
+            size="md"
+            label="ハンドルネーム"
+            placeholder={session?.user?.handleName}
+            value={value}
+            onChange={(event) => setValue(event.currentTarget.value)}
+          />
+        </GridCol>
+        <GridCol span={6} offset={3}>
+          <Flex justify="flex-end" align="center" direction="row">
+            <Button onClick={handleSubmit}>登録</Button>
+          </Flex>
+        </GridCol>
+      </Grid>
+    </Container>
+  );
+}

--- a/src/components/top/Welcome.tsx
+++ b/src/components/top/Welcome.tsx
@@ -91,6 +91,7 @@ function PageContent() {
             label="ハンドルネーム"
             placeholder={session?.user?.handleName}
             value={value}
+            {...(value.includes('User') && { error: 'Userが含まれています。' })}
             onChange={(event) => setValue(event.currentTarget.value)}
           />
         </GridCol>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,6 @@ export { auth as middleware } from '@/auth';
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$|auth|$|terms|privacy|about|thanks|api/auth/callback/google|users/\\d+).*)',
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$|auth|$|welcome|terms|privacy|about|thanks|api/auth/callback/google|users/\\d+).*)',
   ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,6 @@ export { auth as middleware } from '@/auth';
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$|auth|$|welcome|terms|privacy|about|thanks|api/auth/callback/google|users/\\d+).*)',
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$|auth|$|terms|privacy|about|thanks|api/auth/callback/google|users/\\d+).*)',
   ],
 };

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -9,7 +9,7 @@ export type Book = {
 
 export type BookMenuProps = {
   bookId: number;
-  uid: string | undefined;
+  id: string | undefined;
 };
 
 export type DeleteBookModalProps = {
@@ -23,7 +23,7 @@ export type BookProps = {
 
 export type BookItemsProps = {
   bookItems: Book[];
-  uid?: string;
+  id?: string;
 };
 
 export type BookResponse = {

--- a/src/types/memo.ts
+++ b/src/types/memo.ts
@@ -4,6 +4,6 @@ export type Memo = {
 };
 
 export type MemoParams = {
-  id: string | undefined;
+  userId: string | undefined;
   bookId: number;
 };

--- a/src/types/memo.ts
+++ b/src/types/memo.ts
@@ -4,6 +4,6 @@ export type Memo = {
 };
 
 export type MemoParams = {
-  uid: string | undefined;
+  id: string | undefined;
   bookId: number;
 };

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,10 +1,11 @@
 export type UserInfo = {
-  name: string;
+  handleName: string;
   image: string;
   id: string;
 };
 
 export type UserParams = {
-  uid: string | string[] | undefined;
+  id?: string;
+  handleName?: string | string[] | undefined;
   close?: () => void;
 };


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/93

## description
Googleの名前は一意ではないため、別途handleNameを用意して、最初のログイン時はhandleName設定のページを表示するように実装。

Auth.jsの`jwt`コールバックから`GET api/auth/add_session_user_data`を叩いてidとhandleNameを取得し、セッションに載せるようにした。`trigger === 'update'`のときは、welcomeページで入力された値でセッションを更新する。

URLは`/users/[id]`から`/users/[handleName]`に変更し、公開ページと本棚編集ページのパスを合わせた。各リクエストで送るパラメータもuidからuserIdに変更している。
