### PR TITLE
sessionからuidを削除

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -14,7 +14,7 @@ declare module 'next-auth' {
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [Google],
   callbacks: {
-    async jwt({ token, profile, trigger, session }) {
+    async jwt({ token, trigger, session }) {
       if (!token.handleName || !token.id) {
         try {
           const res = await axios.get(
@@ -31,9 +31,6 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           console.warn(error);
         }
       }
-      if (profile) {
-        token.sub = profile.sub || undefined;
-      }
       if (trigger === 'update') {
         token.handleName = session.user.handleName;
       }
@@ -49,11 +46,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       return session;
     },
 
-    async signIn({ user, profile }) {
+    async signIn({ user }) {
       const name = user.name;
       const email = user.email;
       const avatarUrl = user.image;
-      const uid = profile?.sub;
       try {
         const res = await axios.post(
           'http://localhost:3001/api/auth/callback/google',
@@ -61,7 +57,6 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             name,
             email,
             avatarUrl,
-            uid,
           },
         );
         if (res.status === 200 || res.status === 201) {

--- a/src/components/bookshelf/DndList.tsx
+++ b/src/components/bookshelf/DndList.tsx
@@ -24,7 +24,7 @@ export function DndList({ bookItems, id }: BookItemsProps) {
   const [deleteParamsState, setDeleteParamsState] = useSetState({
     bookId: 0,
     position: 0,
-    id: id,
+    userId: id,
   });
   const [opened, { open, close }] = useDisclosure(false);
 
@@ -55,7 +55,7 @@ export function DndList({ bookItems, id }: BookItemsProps) {
     const params = {
       bookId: book?.id,
       destinationBookId: destinationBook?.id,
-      id: id,
+      userId: id,
     };
     try {
       const res = await axios.post(

--- a/src/components/modal/AddBookConfirmModal.tsx
+++ b/src/components/modal/AddBookConfirmModal.tsx
@@ -26,19 +26,13 @@ const AddBookConfirmContent = ({ book }: BookProps) => {
       return;
     }
 
-    const title = book.title;
-    const author = book.author;
-    const coverImageUrl = book.coverImageUrl;
-    const id = session?.user?.id;
-    const headingNumber = value;
-
     try {
       const res = await axios.post('http://localhost:3001/api/books', {
-        title,
-        author,
-        coverImageUrl,
-        id,
-        headingNumber,
+        title: book.title,
+        author: book.author,
+        coverImageUrl: book.coverImageUrl,
+        userId: session?.user.id,
+        headingNumber: value,
       });
       if (res.status === 200) {
         router.push('/');

--- a/src/components/top/Welcome.tsx
+++ b/src/components/top/Welcome.tsx
@@ -37,8 +37,9 @@ function PageContent() {
     }
     try {
       const res = await axios.patch(
-        `http://localhost:3001/api/users/${session?.user?.id}`,
+        `http://localhost:3001/api/users/${session?.user.id}`,
         {
+          user_id: session?.user.id,
           handle_name: value,
         },
       );

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -9,7 +9,7 @@ export type Book = {
 
 export type BookMenuProps = {
   bookId: number;
-  id: string | undefined;
+  userId: string | undefined;
 };
 
 export type DeleteBookModalProps = {


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/98

## description
`auth.ts`のsessionからuidを削除した。あわせて、uidを参照していた`DndList`・`AddBookConfirmModal`と型定義をuserIdに揃えている。
