### PR TITLE
handle_nameに空白を含まないように修正

### DIFF
--- a/src/components/top/Welcome.tsx
+++ b/src/components/top/Welcome.tsx
@@ -35,6 +35,10 @@ function PageContent() {
       toast.error('Userが含まれています。');
       return;
     }
+    if (value.includes(' ')) {
+      toast.error('空白が含まれています。');
+      return;
+    }
     try {
       const res = await axios.patch(
         `http://localhost:3001/api/users/${session?.user?.id}`,
@@ -92,6 +96,7 @@ function PageContent() {
             placeholder={session?.user?.handleName}
             value={value}
             {...(value.includes('User') && { error: 'Userが含まれています。' })}
+            {...(value.includes(' ') && { error: '空白が含まれています。' })}
             onChange={(event) => setValue(event.currentTarget.value)}
           />
         </GridCol>


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/99

## description
welcomeページのhandleNameの入力欄で、空白が含まれている場合にエラーを出すようにした。既存の「Userが含まれています。」のチェックと同じ形で、入力中は`TextInput`にエラーを表示し、送信時はtoastを出して処理を止める。
