### PR TITLE
本の検索結果が1件だった時のレイアウト崩れを修正

### DIFF
--- a/src/components/search/Results.tsx
+++ b/src/components/search/Results.tsx
@@ -6,15 +6,17 @@ import {
   Grid,
   GridCol,
   Flex,
+  Center,
 } from '@mantine/core';
 import AddBookConfirmButton from '../button/AddBookConfirmButton';
 import { BookItemsProps } from '@/types/index';
 
 const Results = ({ bookItems }: BookItemsProps) => {
   return (
-    <Grid justify="center" align="stretch">
-      {bookItems.length > 0
-        ? bookItems.map((book) => (
+    <>
+      {bookItems.length > 1 ? (
+        <Grid justify="center" align="stretch">
+          {bookItems.map((book) => (
             <GridCol span={6} key={book.id}>
               <Card padding="md" withBorder shadow="sm" radius="md">
                 <SimpleGrid cols={{ base: 1, sm: 2 }}>
@@ -39,9 +41,30 @@ const Results = ({ bookItems }: BookItemsProps) => {
                 </SimpleGrid>
               </Card>
             </GridCol>
-          ))
-        : null}
-    </Grid>
+          ))}
+        </Grid>
+      ) : (
+        <Center>
+          <Card padding="md" withBorder shadow="sm" radius="md">
+            <SimpleGrid cols={{ base: 1, sm: 2 }}>
+              <Image
+                radius="lg"
+                w={141}
+                h={200}
+                fit="contain"
+                src={bookItems[0].coverImageUrl}
+                alt={bookItems[0].title}
+              />
+              <Flex gap="sm" justify="center" align="center" direction="column">
+                <Text lineClamp={2}>{bookItems[0].title}</Text>
+                <Text lineClamp={1}>{bookItems[0].author}</Text>
+                <AddBookConfirmButton book={bookItems[0]} />
+              </Flex>
+            </SimpleGrid>
+          </Card>
+        </Center>
+      )}
+    </>
   );
 };
 

--- a/src/components/search/SearchHome.tsx
+++ b/src/components/search/SearchHome.tsx
@@ -4,7 +4,7 @@ import SearchForm from './SearchForm';
 import Results from './Results';
 import { useState } from 'react';
 import { Book } from '@/types/index';
-import { Grid, GridCol, Space, Container } from '@mantine/core';
+import { Grid, GridCol, Space, Container, Text } from '@mantine/core';
 
 const SearchHome = () => {
   const [searchResults, setSearchResults] = useState<Book[]>([]);
@@ -22,8 +22,12 @@ const SearchHome = () => {
         <GridCol>
           <Space h={30} />
         </GridCol>
-        <Results bookItems={searchResults} />
       </Grid>
+      {searchResults.length > 0 ? (
+        <Results bookItems={searchResults} />
+      ) : (
+        <Text ta="center">検索結果がありません。</Text>
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/95

## description
検索結果が1件のときにカードが左寄せで崩れていたため、件数で表示を分けた。2件以上はこれまでどおりGridで2列に並べ、1件のときは`Center`でカードを1枚だけ中央に置く。

### before
<img width="700" alt="スクリーンショット 2024-09-06 11 01 49" src="https://github.com/user-attachments/assets/3ace7374-e3ba-4350-ac24-ab46e7b95179">


### after

<img width="700" alt="スクリーンショット 2024-09-06 11 01 24" src="https://github.com/user-attachments/assets/5b1a9cc4-1e61-4da7-a2bf-ba9914b622b8">
