### PR TITLE
darkmode実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.14",
         "storybook": "^8.1.9",
-        "storybook-dark-mode": "^4.0.1",
+        "storybook-dark-mode": "^4.0.2",
         "tailwindcss": "^3.4.1",
         "ts-node": "^10.9.2",
         "typescript": "^5"
@@ -21223,11 +21223,10 @@
       }
     },
     "node_modules/storybook-dark-mode": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-4.0.1.tgz",
-      "integrity": "sha512-9l3qY8NdgwZnY+NlO1XHB3eUb6FmZo9GazJeUSeFkjRqwA5FmnMSeq0YVqEOqfwniM/TvQwOiTYd5g/hC2wugA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-4.0.2.tgz",
+      "integrity": "sha512-zjcwwQ01R5t1VsakA6alc2JDIRVtavryW8J3E3eKLDIlAMcvsgtpxlelWkZs2cuNspk6Z10XzhQVrUWtYc3F0w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@storybook/components": "^8.0.0",
         "@storybook/core-events": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.14",
     "storybook": "^8.1.9",
-    "storybook-dark-mode": "^4.0.1",
+    "storybook-dark-mode": "^4.0.2",
     "tailwindcss": "^3.4.1",
     "ts-node": "^10.9.2",
     "typescript": "^5"

--- a/src/components/button/ToggleColorButton.tsx
+++ b/src/components/button/ToggleColorButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useMantineColorScheme, ActionIcon, rem } from '@mantine/core';
+import { IconSun, IconMoon } from '@tabler/icons-react';
+
+export default function ToggleColorButton() {
+  const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+
+  return (
+    <ActionIcon
+      size={34}
+      variant="default"
+      aria-label="ActionIcon to switch color"
+      onClick={toggleColorScheme}
+    >
+      {colorScheme === 'light' ? (
+        <IconMoon style={{ width: rem(20), height: rem(20) }} />
+      ) : (
+        <IconSun style={{ width: rem(20), height: rem(20) }} />
+      )}
+    </ActionIcon>
+  );
+}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,6 +2,7 @@ import { auth } from '@/auth';
 import { Group, Text, Container } from '@mantine/core';
 import Image from 'next/image';
 import UserMenu from './UserMenu';
+import ToggleColorButton from '@/components/button/ToggleColorButton';
 import Link from 'next/link';
 
 export async function Header() {
@@ -19,7 +20,7 @@ export async function Header() {
               </Text>
             </Group>
           </Link>
-          <Group ml="xl" gap={0}>
+          <Group ml="xl">
             {session?.user && (
               <UserMenu
                 name={session.user.name!}
@@ -27,6 +28,7 @@ export async function Header() {
                 image={session.user.image!}
               />
             )}
+            <ToggleColorButton />
           </Group>
         </Group>
       </Group>

--- a/src/stories/button/ToggleColorButton.stories.ts
+++ b/src/stories/button/ToggleColorButton.stories.ts
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ToggleColorButton from '@/components/button/ToggleColorButton';
+import { userEvent, within, expect, waitFor } from '@storybook/test';
+
+const meta: Meta<typeof ToggleColorButton> = {
+  component: ToggleColorButton,
+  parameters: {
+    layout: 'centered',
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ToggleColorButton>;
+
+export const AppearenceTest: Story = {
+  args: {},
+};
+
+export const ToggleColorTest: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      const theme = document.documentElement.getAttribute(
+        'data-mantine-color-scheme',
+      );
+      expect(theme === 'light');
+    });
+
+    const button = canvas.getByLabelText('ActionIcon to switch color');
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      const theme = document.documentElement.getAttribute(
+        'data-mantine-color-scheme',
+      );
+      expect(theme === 'dark');
+    });
+  },
+};


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/96

## description
Mantineのcolor schemeを使ってダークモードに対応した。`ToggleColorButton`を追加してヘッダーに置き、`useMantineColorScheme`の`toggleColorScheme`で切り替える。アイコンは現在の配色に応じて月と太陽を出し分けている。storyも追加した。
