### PR TITLE
cookieオプション追加

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,6 +7,17 @@ const apiUrl: string = process.env.NEXT_PUBLIC_RAILS_API_URL ?? '';
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [Google],
+  cookies: {
+    pkceCodeVerifier: {
+      name: "next-auth.pkce.code_verifier",
+      options: {
+        httpOnly: true,
+        sameSite: "none",
+        path: "/",
+        secure: true,
+      },
+    },
+  },
   callbacks: {
     async jwt({ token }) {
       if (!token.id) {


### PR DESCRIPTION
## Issue
対応するIssueはなし。

## description

本番環境で下記エラーが出たため。
```
^[[31m[auth][error]^[[0m InvalidCheck: PKCE code_verifier cookie was missing.. Read more at https://errors.authjs.dev#invalidcheck
```

Auth.jsの`cookies.pkceCodeVerifier`に、`httpOnly`・`sameSite: 'none'`・`secure: true`などのオプションを明示的に設定した。

この設定は翌日のfrontend PR #50で削除している。
