### PR TITLE
cookieオプション削除

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,17 +7,6 @@ const apiUrl: string = process.env.NEXT_PUBLIC_RAILS_API_URL ?? '';
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [Google],
-  cookies: {
-    pkceCodeVerifier: {
-      name: "next-auth.pkce.code_verifier",
-      options: {
-        httpOnly: true,
-        sameSite: "none",
-        path: "/",
-        secure: true,
-      },
-    },
-  },
   callbacks: {
     async jwt({ token }) {
       if (!token.id) {


### PR DESCRIPTION
## Issue
対応するIssueはなし。

## description

下記PRの対応が不要だった。
原因不明だが、おそらく環境変数が誤っていてsignIn後のバックエンドへのリクエストがうまく行ってなかったと思う。

- https://github.com/reckyy/tsundoku-frontend/pull/49

PR #49で追加した`cookies.pkceCodeVerifier`の設定をそのまま元に戻した。
