### PR TITLE
章が見切れないように修正

### DIFF
--- a/src/app/(authenticated)/books/[bookId]/memos/page.tsx
+++ b/src/app/(authenticated)/books/[bookId]/memos/page.tsx
@@ -9,6 +9,8 @@ import {
   Text,
   GridCol,
   Space,
+  Paper,
+  ScrollArea,
 } from '@mantine/core';
 import { useParams } from 'next/navigation';
 import { useSession, SessionProvider } from 'next-auth/react';
@@ -142,19 +144,23 @@ function PageContent() {
             />
           </GridCol>
           <GridCol offset={1} span={6}>
-            <Text size="md" ta={'center'} mb={7}>
-              章
-            </Text>
-            <SegmentedControl
-              value={heading}
-              onChange={setHeading}
-              fullWidth
-              data={
-                bookWithMemos?.headings.map((heading) =>
-                  String(heading.number),
-                ) ?? []
-              }
-            />
+            <Paper withBorder shadow="xs" radius="md" p="xl">
+              <Text size="md" ta={'center'} mb={7}>
+                章
+              </Text>
+              <ScrollArea scrollHideDelay={0}>
+                <SegmentedControl
+                  value={heading}
+                  onChange={setHeading}
+                  fullWidth
+                  data={
+                    bookWithMemos?.headings.map((heading) =>
+                      String(heading.number),
+                    ) ?? []
+                  }
+                />
+              </ScrollArea>
+            </Paper>
           </GridCol>
         </Grid>
         <Space h={50} />

--- a/src/stories/cal/Cal.stories.ts
+++ b/src/stories/cal/Cal.stories.ts
@@ -33,9 +33,9 @@ const readingCalendarogs = [
 export const AppearenceTest: Story = {
   parameters: {
     msw: {
-      handCalendarers: [
+      handlers: [
         http.get(
-          `${process.env.NEXT_PUBCalendarIC_RAICalendarS_API_URCalendar}/reading_Calendarogs`,
+          `${process.env.NEXT_PUBLIC_RAILS_API_URL}/reading_logs`,
           () => {
             return HttpResponse.json(readingCalendarogs);
           },


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/126

## description
章数が多いときに`SegmentedControl`が画面幅に収まらず、後ろの章をクリックできなくなっていた。`ScrollArea`で囲んで横スクロールできるようにし、あわせて`Paper`で枠を付けた。

`Cal`から`Calendar`への改名時の置換ミスで、storyの`handlers`が`handCalendarers`になっていた箇所もあわせて直している。
