### PR TITLE
スマホでの画面の不具合を修正

### DIFF
--- a/src/app/(authenticated)/books/[bookId]/memos/page.tsx
+++ b/src/app/(authenticated)/books/[bookId]/memos/page.tsx
@@ -12,13 +12,20 @@ import {
   Paper,
   ScrollArea,
 } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import { useParams } from 'next/navigation';
 import { useSession, SessionProvider } from 'next-auth/react';
 import { useState } from 'react';
 import useSWR from 'swr';
 import axios from 'axios';
 import toast from 'react-hot-toast';
-import { MemoParams, BookWithMemo, HandleSaveType } from '@/types/index';
+import {
+  MemoParams,
+  BookWithMemo,
+  HandleSaveType,
+  Heading,
+  GridItemType,
+} from '@/types/index';
 import MemoLoading from '@/components/loading/MemoLoading';
 
 export default function Page() {
@@ -28,8 +35,44 @@ export default function Page() {
     </SessionProvider>
   );
 }
+function GridItem({
+  imageSpan,
+  headingSpan,
+  offset,
+  imageSrc,
+  imageAlt,
+  headings,
+  heading,
+  setHeading,
+}: GridItemType) {
+  return (
+    <>
+      <GridCol span={imageSpan}>
+        <Image radius="lg" w={141} h={200} src={imageSrc} alt={imageAlt} />
+      </GridCol>
+      <GridCol offset={offset} span={headingSpan}>
+        <Paper withBorder shadow="xs" radius="md" p="xl">
+          <Text size="md" ta={'center'} mb={7}>
+            章
+          </Text>
+          <ScrollArea scrollHideDelay={0}>
+            <SegmentedControl
+              value={heading}
+              onChange={setHeading}
+              fullWidth
+              data={
+                headings.map((heading: Heading) => String(heading.number)) ?? []
+              }
+            />
+          </ScrollArea>
+        </Paper>
+      </GridCol>
+    </>
+  );
+}
 
 function PageContent() {
+  const matches = useMediaQuery('(min-width: 48em)');
   const apiUrl: string = process.env.NEXT_PUBLIC_RAILS_API_URL ?? '';
   const dynamicParams = useParams<{ bookId: string }>();
   const bookId = Number(dynamicParams.bookId);
@@ -134,35 +177,18 @@ function PageContent() {
       <title>{`${bookWithMemos?.book.title}のメモページ`}</title>
       <Container my={'md'}>
         <Grid>
-          <GridCol span={3}>
-            <Image
-              radius="lg"
-              w={141}
-              h={200}
-              src={bookWithMemos?.book.coverImageUrl}
-              alt={bookWithMemos?.book.title}
-            />
-          </GridCol>
-          <GridCol offset={1} span={6}>
-            <Paper withBorder shadow="xs" radius="md" p="xl">
-              <Text size="md" ta={'center'} mb={7}>
-                章
-              </Text>
-              <ScrollArea scrollHideDelay={0}>
-                <SegmentedControl
-                  value={heading}
-                  onChange={setHeading}
-                  fullWidth
-                  data={
-                    bookWithMemos?.headings.map((heading) =>
-                      String(heading.number),
-                    ) ?? []
-                  }
-                />
-              </ScrollArea>
-            </Paper>
-          </GridCol>
+          <GridItem
+            imageSpan={matches ? 3 : undefined}
+            headingSpan={matches ? 6 : undefined}
+            offset={matches ? 1 : undefined}
+            imageSrc={bookWithMemos?.book.coverImageUrl}
+            imageAlt={bookWithMemos?.book.title}
+            headings={bookWithMemos?.headings || []}
+            heading={heading}
+            setHeading={setHeading}
+          />
         </Grid>
+
         <Space h={50} />
         <Editor
           heading={bookWithMemos?.headings[Number(heading) - 1]}

--- a/src/components/appShell/MyAppShell.tsx
+++ b/src/components/appShell/MyAppShell.tsx
@@ -20,7 +20,7 @@ export default async function MyAppShell({ children }: PropsWithChildren) {
       </AppShellHeader>
 
       <AppShellMain>{children}</AppShellMain>
-      <AppShellFooter p="md">
+      <AppShellFooter p="md" visibleFrom="sm">
         <Footer />
       </AppShellFooter>
     </AppShell>

--- a/src/components/calendar/CalendarContent.tsx
+++ b/src/components/calendar/CalendarContent.tsx
@@ -7,7 +7,7 @@ import { ReadingLogs } from '@/types/index';
 
 export default function CalendarContent({ readingLogs }: ReadingLogs) {
   const value = readingLogs.map((log) => ({
-    date: log.date.replace('-', '/'),
+    date: log.date.replaceAll('-', '/'),
     count: log.count,
   }));
   const today = new Date();

--- a/src/types/memo.ts
+++ b/src/types/memo.ts
@@ -1,3 +1,4 @@
+import { Heading } from './heading';
 export type Memo = {
   id: number;
   body: string;
@@ -6,4 +7,15 @@ export type Memo = {
 export type MemoParams = {
   userId: string | undefined;
   bookId: number;
+};
+
+export type GridItemType = {
+  imageSpan: number | undefined;
+  headingSpan: number | undefined;
+  offset: number | undefined;
+  imageSrc: string | undefined;
+  imageAlt: string | undefined;
+  headings: Heading[];
+  heading: string;
+  setHeading: React.Dispatch<React.SetStateAction<string>>;
 };


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/132

## description
スマホでの表示の不具合を3つ直した。

読書ログが空白になっていたのは、`CalendarContent`の日付整形が`replace('-', '/')`で最初のハイフンしか置換されず、`2024/09-20`のような文字列になっていたため。`replaceAll`に変更した。

Footerが画面を隠す件は、`AppShellFooter`に`visibleFrom="sm"`を指定してスマホ幅では表示しないようにした。

メモ画面の表紙が見切れる件は、`useMediaQuery('(min-width: 48em)')`で画面幅を見て`Grid`のspanとoffsetを切り替えるようにし、表紙と章のセレクタを`GridItem`に切り出して`GridItemType`を型定義に追加した。
