### PR TITLE
自分のメモしかアクセスできないように制限

### DIFF
--- a/src/app/(authenticated)/bookshelf/edit/page.tsx
+++ b/src/app/(authenticated)/bookshelf/edit/page.tsx
@@ -21,6 +21,7 @@ export default async function Page() {
       title: book.title,
       author: book.author,
       coverImageUrl: book.cover_image_url,
+      userId: book.user_id,
     }));
   };
 
@@ -31,7 +32,7 @@ export default async function Page() {
         {session?.user?.name}さんの本棚
       </Title>
       <Space h={30} />
-      <DndList bookItems={bookItems} id={session?.user?.id} />
+      <DndList bookItems={bookItems} userId={session?.user?.id} />
     </Container>
   );
 }

--- a/src/app/(shared)/users/[id]/page.tsx
+++ b/src/app/(shared)/users/[id]/page.tsx
@@ -30,7 +30,6 @@ export default function Page() {
         const fetchedBookItems = data.books.map((book: BookResponse) => ({
           id: book.id,
           title: book.title,
-          author: book.author,
           coverImageUrl: book.cover_image_url,
         }));
         setBookItems(fetchedBookItems);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,12 +24,13 @@ export default async function Home() {
       return res.data.map((book: BookResponse) => ({
         id: book.id,
         title: book.title,
-        author: book.author,
         coverImageUrl: book.cover_image_url,
+        userId: book.user_id,
       }));
     };
 
     const bookItems = await getBooks();
+    console.log(bookItems);
 
     return (
       <Container my="md">

--- a/src/components/bookshelf/BookItem.tsx
+++ b/src/components/bookshelf/BookItem.tsx
@@ -10,7 +10,7 @@ const BookItemContent = ({ book }: BookProps) => {
 
   return (
     <>
-      {session ? (
+      {session && Number(session?.user?.id) === book.userId ? (
         <Link href={`/books/${book.id}/memos`}>
           <Image
             radius="md"

--- a/src/components/bookshelf/BookItems.tsx
+++ b/src/components/bookshelf/BookItems.tsx
@@ -1,6 +1,6 @@
 import BookItem from './BookItem';
 import { Grid, GridCol, Space, Center, Text } from '@mantine/core';
-import { BookItemsProps, Book } from '@/types/index';
+import { BookItemsProps, UserBook } from '@/types/index';
 
 const BookItems = ({ bookItems }: BookItemsProps) => {
   return (
@@ -10,7 +10,7 @@ const BookItems = ({ bookItems }: BookItemsProps) => {
           <GridCol span={12}>
             <Space h={40} />
           </GridCol>
-          {bookItems.map((book: Book) => (
+          {bookItems.map((book: UserBook) => (
             <GridCol span={{ base: 6, sm: 4 }} key={book.id}>
               <Center>
                 <BookItem book={book} />

--- a/src/components/bookshelf/DndList.tsx
+++ b/src/components/bookshelf/DndList.tsx
@@ -12,23 +12,23 @@ import {
 } from '@mantine/core';
 import { useListState, useDisclosure, useSetState } from '@mantine/hooks';
 import { IconTrash } from '@tabler/icons-react';
-import { BookItemsProps, Book } from '@/types/index';
+import { BookItemsProps, UserBook } from '@/types/index';
 import axios from 'axios';
 import DeleteBookConfirmModal from '../modal/DeleteBookConfirmModal';
 import toast from 'react-hot-toast';
 import { useState } from 'react';
 
-export default function DndList({ bookItems, id }: BookItemsProps) {
+export default function DndList({ bookItems, userId }: BookItemsProps) {
   const [source, setSource] = useState<number>(0);
   const [state, stateHandlers] = useListState(bookItems);
   const [deleteParamsState, setDeleteParamsState] = useSetState({
     bookId: 0,
     position: 0,
-    userId: id,
+    userId: userId,
   });
   const [opened, { open, close }] = useDisclosure(false);
 
-  const handleClick = (item: Book) => {
+  const handleClick = (item: UserBook) => {
     setDeleteParamsState({ bookId: item.id, position: state.indexOf(item) });
     open();
   };
@@ -57,7 +57,7 @@ export default function DndList({ bookItems, id }: BookItemsProps) {
     const params = {
       bookId: book?.id,
       destinationBookId: destinationBook?.id,
-      userId: id,
+      userId: userId,
     };
     const apiUrl: string = process.env.NEXT_PUBLIC_RAILS_API_URL ?? '';
     try {

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -3,8 +3,16 @@ import { Heading } from './heading';
 export type Book = {
   id: number;
   title: string;
-  author: string;
+  author?: string;
   coverImageUrl: string;
+};
+
+export type UserBook = {
+  id: number;
+  title: string;
+  author?: string;
+  coverImageUrl: string;
+  userId?: number;
 };
 
 export type BookMenuProps = {
@@ -18,12 +26,12 @@ export type DeleteBookModalProps = {
 };
 
 export type BookProps = {
-  book: Book;
+  book: UserBook;
 };
 
 export type BookItemsProps = {
-  bookItems: Book[];
-  id?: string;
+  bookItems: UserBook[];
+  userId?: string;
 };
 
 export type BookResponse = {
@@ -31,8 +39,7 @@ export type BookResponse = {
   title: string;
   author: string;
   cover_image_url: string;
-  created_at: string;
-  updated_at: string;
+  user_id?: number;
 };
 
 export type BookWithMemo = {


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/128

## description
公開ページで、他のユーザーの本にもメモ画面へのリンクが出てしまう問題を直した。`BookItem`の条件を`session`の有無だけから`Number(session?.user?.id) === book.userId`に変更し、自分の本のときだけリンクを表示する。

Railsから受け取ったuser_idを持たせるため、`Book`とは別に`UserBook`型を追加した。公開ページと本棚では著者名を表示していないため、マッピングから`author`も外している。
