### PR TITLE
token認証の方法を変更

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,7 +5,7 @@ import { axiosInstance } from '@/lib/axios';
 
 declare module 'next-auth' {
   interface User {
-    accessToken: string;
+    idToken: string;
   }
 }
 
@@ -13,21 +13,21 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [Google],
   callbacks: {
     async jwt({ token, user }) {
-      if (user?.id && user?.accessToken) {
+      if (user?.id && user?.idToken) {
         token.id = user.id;
-        token.accessToken = user.accessToken;
+        token.idToken = user.idToken;
       }
       return token;
     },
     async session({ session, token }) {
-      if (token.accessToken && token.id) {
+      if (token.idToken && token.id) {
         session.user.id = token.id as string;
-        session.user.accessToken = token.accessToken as string;
+        session.user.idToken = token.idToken as string;
       }
       return session;
     },
 
-    async signIn({ user }) {
+    async signIn({ user, account }) {
       const name = user.name;
       const email = user.email;
       const avatarUrl = user.image;
@@ -39,7 +39,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         });
         if (res.status === 200) {
           user.id = res.data.id;
-          user.accessToken = res.data.token;
+          user.idToken = account?.id_token as string;
           return true;
         } else {
           return false;

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -4,7 +4,7 @@ import { axiosInstance, setHeader } from '@/lib/axios';
 
 export default async function Calendar() {
   const session = await auth();
-  const token = session?.user?.accessToken;
+  const token = session?.user?.idToken;
   await setHeader(token!);
   const res = await axiosInstance.get('/reading_logs', {});
   const readingLogs = res.data.logs;

--- a/src/components/confirm/ConfirmDeletion.tsx
+++ b/src/components/confirm/ConfirmDeletion.tsx
@@ -17,7 +17,7 @@ import DeleteAccountButton from '../button/DeleteAccountButton';
 export default async function ConfirmDeletion() {
   const session = await auth();
   const id = session?.user?.id;
-  const token = session?.user?.accessToken;
+  const token = session?.user?.idToken;
   return (
     <Container my="md">
       <Title order={3} ta="center">

--- a/src/components/pageContent/BookShelfPageContent.tsx
+++ b/src/components/pageContent/BookShelfPageContent.tsx
@@ -5,7 +5,7 @@ import getBooks from '@/utils/getBooks';
 
 export default async function BookShelfPageContent() {
   const session = await auth();
-  const token = session?.user?.accessToken;
+  const token = session?.user?.idToken;
   const bookItems = await getBooks(token!);
 
   return (

--- a/src/components/pageContent/MemoPageContent.tsx
+++ b/src/components/pageContent/MemoPageContent.tsx
@@ -74,7 +74,7 @@ export default function MemoPageContent() {
   const dynamicParams = useParams<{ bookId: string }>();
   const bookId = Number(dynamicParams.bookId);
   const { data: session, status } = useSession();
-  const token = session?.user?.accessToken;
+  const token = session?.user?.idToken;
   const params = {
     bookId,
   };

--- a/src/components/pageContent/TopPageContent.tsx
+++ b/src/components/pageContent/TopPageContent.tsx
@@ -8,7 +8,7 @@ import getBooks from '@/utils/getBooks';
 export default async function TopPageContent() {
   const session = await auth();
   if (session?.user) {
-    const bookItems = await getBooks(session.user.accessToken);
+    const bookItems = await getBooks(session.user.idToken);
 
     return (
       <Container my="md">

--- a/src/hooks/useAddBook.ts
+++ b/src/hooks/useAddBook.ts
@@ -7,7 +7,7 @@ import { axiosInstance, setHeader } from '@/lib/axios';
 
 const useAddBook = (book: Book) => {
   const { data: session } = useSession();
-  const token = session?.user?.accessToken;
+  const token = session?.user?.idToken;
   const router = useRouter();
   const [value, setValue] = useState<string | number>('');
 


### PR DESCRIPTION
## Issue
対応するIssueはなし。backend PR #31 のレビューコメントから派生した対応。

- https://github.com/reckyy/tsundoku-backend/pull/31#discussion_r1797780560

## description
Railsへ送るトークンを、自前で発行したJWT（`accessToken`）からGoogleのID Token（`idToken`）に変更した。

`signIn`コールバックで`account.id_token`を受け取ってセッションに載せ、`jwt` / `session`コールバックの型と受け渡しも`accessToken`から`idToken`に置き換えている。各リクエストで`Authorization`ヘッダに載せる値も差し替えた。
