### PR TITLE
metadataを正しく設定

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,39 +2,34 @@ import type { Metadata } from 'next';
 import TopLoading from '@/components/loading/TopLoading';
 import TopPageContent from '@/components/pageContent/TopPageContent';
 import { Suspense } from 'react';
-import Head from 'next/head';
+
+const imageUrl = 'https://tsundoku.tech/images/tsundoku.png';
 
 export const metadata: Metadata = {
   title: 'Tsundoku',
   description:
     'Tsundokuは読書が続かない人、積読しがちな人向けの読書管理アプリです。読んできた本の一覧表示と読書ログを公開することにより、外部に読書習慣をアピールできます！',
+  openGraph: {
+    title: 'Tsundoku',
+    description: '読書習慣を身につけよう。',
+    images: {
+      url: imageUrl,
+      width: 1200,
+      height: 630,
+    },
+    url: 'https://tsundoku.tech',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Tsundoku',
+    description: '読書習慣を身につけよう。',
+    images: imageUrl,
+  },
 };
 
 export default function Home() {
   return (
     <>
-      <Head>
-        <meta property="og:title" content="Tsundoku" />
-        <meta
-          property="og:description"
-          content="Tsundokuは読書が続かない人、積読しがちな人向けの読書管理アプリです。読んできた本の一覧表示と読書ログを公開することにより、外部に読書習慣をアピールできます！"
-        />
-        <meta
-          property="og:image"
-          content="https://tsundoku.tech/images/tsundoku.png"
-        />
-        <meta property="og:url" content="https://tsundoku.tech" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Tsundoku" />
-        <meta
-          name="twitter:description"
-          content="Tsundokuは読書が続かない人、積読しがちな人向けの読書管理アプリです。読んできた本の一覧表示と読書ログを公開することにより、外部に読書習慣をアピールできます！"
-        />
-        <meta
-          name="twitter:image"
-          content="https://tsundoku.tech/images/tsundoku.png"
-        />
-      </Head>
       <Suspense fallback={<TopLoading />}>
         <TopPageContent />
       </Suspense>

--- a/src/components/pageContent/UserPageContent.tsx
+++ b/src/components/pageContent/UserPageContent.tsx
@@ -20,6 +20,7 @@ import { axiosInstance } from '@/lib/axios';
 import { useClipboard } from '@mantine/hooks';
 import toast from 'react-hot-toast';
 import { useSession } from 'next-auth/react';
+import Head from 'next/head';
 
 export default function UserPageContent() {
   const { data: session } = useSession();
@@ -31,6 +32,8 @@ export default function UserPageContent() {
   const [readingLogs, setReadingLogs] = useState<Log[]>([]);
   const [userName, setUserName] = useState<string>('');
   const clipboard = useClipboard();
+  const description = `${userName}の読書記録ページです！`;
+  const imageUrl = 'https://tsundoku.tech/images/tsundoku.png';
 
   const handleCopyUrl = () => {
     clipboard.copy(userPageUrl);
@@ -63,7 +66,22 @@ export default function UserPageContent() {
 
   return (
     <>
-      <title>{`${userName}さんの公開ページ`}</title>
+      <Head>
+        <title>{`${userName}のページ | Tsundoku`}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={`${userName}のページ | Tsundoku`} />
+        <meta property="og:description" content={description} />
+        <meta property="og:image" content={imageUrl} />
+        <meta
+          property="og:url"
+          content={`https://tsundoku.tech/users/${userName}`}
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={`${userName}のページ | Tsundoku`} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={imageUrl} />
+      </Head>
+
       {String(session?.user?.id) === dynamicParams.id && (
         <Container bg={'var(--mantine-color-blue-light'} h={150} mt="md">
           <Stack pt="md" align="center" justify="center">


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/138
- https://github.com/reckyy/tsundoku/issues/8

## description
OGPが表示されていなかったので、metadataを修正。

ルートページは`next/head`の`Head`でmetaタグを書いていたが効いていなかったため、`export const metadata`の`openGraph`と`twitter`に移した。公開ページはクライアントコンポーネントで`metadata`が使えないため、`Head`でユーザー名入りのタイトル・description・画像を設定している。
