### PR TITLE
スマホでのレイアウト崩れの修正

### DIFF
--- a/src/components/bookshelf/BookItems.tsx
+++ b/src/components/bookshelf/BookItems.tsx
@@ -32,22 +32,38 @@ const BookItems = ({ bookItems, isPublic }: BookItemsProps) => {
   return (
     <>
       <Space h={20} />
-      <Grid>
-        <GridCol offset={2} span={8}>
+      {isLargeScreen ? (
+        <Grid>
+          <GridCol offset={2} span={8}>
+            <SegmentedControl
+              color="blue"
+              fullWidth
+              value={filter}
+              onChange={(value) => setFilter(value as Filter)}
+              size="md"
+              data={[
+                { label: 'まだ読んでない', value: 'unread_books' },
+                { label: '読んでる途中', value: 'reading_books' },
+                { label: '全部読んだ', value: 'finished_books' },
+              ]}
+            />
+          </GridCol>
+        </Grid>
+      ) : (
+        <Center>
           <SegmentedControl
             color="blue"
-            fullWidth
             value={filter}
             onChange={(value) => setFilter(value as Filter)}
-            size={isLargeScreen ? 'md' : 'sm'}
+            size="sm"
             data={[
               { label: 'まだ読んでない', value: 'unread_books' },
-              { label: ' 読んでる途中 ', value: 'reading_books' },
+              { label: '読んでる途中', value: 'reading_books' },
               { label: '全部読んだ', value: 'finished_books' },
             ]}
           />
-        </GridCol>
-      </Grid>
+        </Center>
+      )}
       <Space h={20} />
       {filteredBooks.length > 0 ? (
         <Grid>

--- a/src/components/bookshelf/DndList.tsx
+++ b/src/components/bookshelf/DndList.tsx
@@ -178,22 +178,39 @@ function DndListContent({ bookItems }: DndListProps) {
         />
       </Modal>
       <Space h={20} />
-      <Grid>
-        <GridCol offset={2} span={8}>
+      {isLargeScreen ? (
+        <Grid>
+          <GridCol offset={2} span={8}>
+            <SegmentedControl
+              color="blue"
+              fullWidth
+              value={filter}
+              onChange={(value) => setFilter(value as Filter)}
+              size="md"
+              data={[
+                { label: 'まだ読んでない', value: 'unread_books' },
+                { label: '読んでる途中', value: 'reading_books' },
+                { label: '全部読んだ', value: 'finished_books' },
+              ]}
+            />
+          </GridCol>
+        </Grid>
+      ) : (
+        <Center>
           <SegmentedControl
             color="blue"
-            fullWidth
             value={filter}
             onChange={(value) => setFilter(value as Filter)}
-            size={isLargeScreen ? 'md' : 'sm'}
+            size="sm"
             data={[
               { label: 'まだ読んでない', value: 'unread_books' },
               { label: '読んでる途中', value: 'reading_books' },
               { label: '全部読んだ', value: 'finished_books' },
             ]}
           />
-        </GridCol>
-      </Grid>
+        </Center>
+      )}
+
       <Space h={20} />
       {items.length > 0 ? (
         items

--- a/src/components/pageContent/MemoPageContent.tsx
+++ b/src/components/pageContent/MemoPageContent.tsx
@@ -14,6 +14,7 @@ import {
   ActionIcon,
   rem,
   Tooltip,
+  Center,
 } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import { useMediaQuery } from '@mantine/hooks';
@@ -33,6 +34,7 @@ type GridItemType = {
   imageSpan: number | undefined;
   bookInfoSpan: number | undefined;
   offset: number | undefined;
+  isLargeScreen: boolean | undefined;
   bookWithMemos: BookWithMemos;
   setBookWithMemos: React.Dispatch<
     React.SetStateAction<BookWithMemos | undefined>
@@ -43,6 +45,7 @@ function GridItem({
   imageSpan,
   bookInfoSpan,
   offset,
+  isLargeScreen,
   bookWithMemos,
   setBookWithMemos,
 }: GridItemType) {
@@ -72,10 +75,10 @@ function GridItem({
         <SegmentedControl
           mt="md"
           color="blue"
-          fullWidth
+          fullWidth={isLargeScreen}
           value={bookWithMemos.status}
           onChange={(value) => handleSubmit(value)}
-          size="md"
+          size={isLargeScreen ? 'md' : 'sm'}
           data={[
             { label: 'まだ読んでない', value: 'unread' },
             { label: '読んでる途中', value: 'reading' },
@@ -199,19 +202,53 @@ export default function MemoPageContent() {
             imageSpan={isLargeScreen ? 3 : undefined}
             bookInfoSpan={isLargeScreen ? 8 : undefined}
             offset={isLargeScreen ? 1 : undefined}
+            isLargeScreen={isLargeScreen}
             bookWithMemos={bookWithMemos}
             setBookWithMemos={setBookWithMemos}
           />
         </Grid>
         <Space h="20" />
-        <Grid>
-          <GridCol span={9}>
+        {isLargeScreen ? (
+          <Grid>
+            <GridCol span={9}>
+              <ScrollArea scrollHideDelay={0}>
+                <SegmentedControl
+                  value={heading}
+                  onChange={setHeading}
+                  fullWidth
+                  size="md"
+                  data={
+                    bookWithMemos.headings.map((heading: Heading) => ({
+                      label: `${heading.number}章`,
+                      value: String(heading.number),
+                    })) ?? []
+                  }
+                />
+              </ScrollArea>
+            </GridCol>
+            <GridCol span={1}>
+              <Tooltip label="章を追加">
+                <ActionIcon
+                  size={44}
+                  variant="default"
+                  onClick={handleAddNewHeading}
+                >
+                  <IconPlus
+                    style={{ width: rem(24), height: rem(24) }}
+                    stroke={3}
+                  />
+                </ActionIcon>
+              </Tooltip>
+            </GridCol>
+          </Grid>
+        ) : (
+          <Center>
             <ScrollArea scrollHideDelay={0}>
               <SegmentedControl
                 value={heading}
                 onChange={setHeading}
                 fullWidth
-                size="md"
+                size="sm"
                 data={
                   bookWithMemos.headings.map((heading: Heading) => ({
                     label: `${heading.number}章`,
@@ -220,11 +257,10 @@ export default function MemoPageContent() {
                 }
               />
             </ScrollArea>
-          </GridCol>
-          <GridCol span={1}>
             <Tooltip label="章を追加">
               <ActionIcon
-                size={44}
+                size={36}
+                ml="xs"
                 variant="default"
                 onClick={handleAddNewHeading}
               >
@@ -234,8 +270,9 @@ export default function MemoPageContent() {
                 />
               </ActionIcon>
             </Tooltip>
-          </GridCol>
-        </Grid>
+          </Center>
+        )}
+
         <Space h={50} />
         <Editor
           heading={bookWithMemos?.headings[Number(heading) - 1]}

--- a/src/components/pageContent/UserPageContent.tsx
+++ b/src/components/pageContent/UserPageContent.tsx
@@ -32,7 +32,6 @@ export default function UserPageContent({
   isCurrentUser,
 }: UserPageContentProps) {
   const clipboard = useClipboard();
-  console.log(userData);
   const userPageUrl = `${process.env.NEXT_PUBLIC_NEXT_URL}/users/${id}`;
 
   const handleCopyUrl = () => {


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/141

## description
最低限、スマホでも見る可能性の高いページは修正した。
メモ画面はPCで使う想定なので、優先度は低いかつ時間もないため、今回は未対応。

読書ステータスの`SegmentedControl`を画面幅で出し分け、広い画面では`Grid`内で`fullWidth`、狭い画面では`Center`に小さいサイズで置くようにした。本棚（`BookItems`）と本棚編集（`DndList`）の両方に適用している。
