### PR TITLE
読書ログの年度を切り替えられるように実装

### DIFF
--- a/src/components/calendar/CalendarContent.tsx
+++ b/src/components/calendar/CalendarContent.tsx
@@ -1,66 +1,120 @@
 'use client';
 
-import { ScrollArea, Center } from '@mantine/core';
+import { ScrollArea, Center, Group, Menu, Button } from '@mantine/core';
 import HeatMap from '@uiw/react-heat-map';
 import Tooltip from '@uiw/react-tooltip';
 import { Log } from '@/types/index';
+import { useState } from 'react';
+import { IconChevronDown } from '@tabler/icons-react';
 
 type ReadingLogs = {
-  readingLogs: Log[];
+  readingLogs: Record<string, Log[]>;
+};
+
+type YearItem = {
+  label: string;
+  target: string;
 };
 
 export default function CalendarContent({ readingLogs }: ReadingLogs) {
-  const value = readingLogs.map((log) => ({
+  const today = new Date();
+  const currentYear = String(today.getFullYear());
+  const [year, setYear] = useState(currentYear);
+  const value = readingLogs[year].map((log) => ({
     date: log.date.replaceAll('-', '/'),
     count: log.count,
   }));
-  const today = new Date();
-  const currentYear = today.getFullYear();
+  const data = Object.keys(readingLogs)
+    .reverse()
+    .map((year) => ({
+      label: year,
+      target: year,
+    }));
+  const selected = data.find((item) => item.target === year) || data[0];
+
+  const handleClick = (item: YearItem) => {
+    setYear(item.target);
+  };
+  const items = data.map((item) => (
+    <Menu.Item onClick={() => handleClick(item)} key={item.label}>
+      {item.target}
+    </Menu.Item>
+  ));
+
   return (
-    <Center>
-      <ScrollArea w={600}>
-        <HeatMap
-          value={value}
-          width={720}
-          weekLabels={false}
-          monthLabels={[
-            '1月',
-            '2月',
-            '3月',
-            '4月',
-            '5月',
-            '6月',
-            '7月',
-            '8月',
-            '9月',
-            '10月',
-            '11月',
-            '12月',
-          ]}
-          startDate={new Date(`${currentYear}/01/01`)}
-          endDate={today}
-          rectProps={{ rx: 3.5 }}
-          rectSize={12}
-          legendCellSize={0}
-          space={2.4}
-          panelColors={{
-            1: '#c6e48b',
-            2: '#32CD32',
-            4: '#009900',
-            6: '#006400',
-          }}
-          rectRender={(props, data) => {
-            return (
-              <Tooltip
-                placement="top"
-                content={`${data.count || 0} logs on ${data.date}`}
+    <>
+      <Center>
+        <Group
+          mb="sm"
+          justify="flex-end"
+          style={{ width: '100%', maxWidth: '600px' }}
+        >
+          <Menu shadow="md" width={200}>
+            <Menu.Target>
+              <Button
+                variant="default"
+                rightSection={<IconChevronDown size={14} />}
               >
-                <rect {...props} />
-              </Tooltip>
-            );
-          }}
-        />
-      </ScrollArea>
-    </Center>
+                {`Year: ${selected.target}`}
+              </Button>
+            </Menu.Target>
+
+            <Menu.Dropdown>{items}</Menu.Dropdown>
+          </Menu>
+        </Group>
+      </Center>
+
+      <Center>
+        <ScrollArea w={600}>
+          <HeatMap
+            key={`${year}-heatmap`}
+            value={value}
+            width={775}
+            weekLabels={false}
+            monthLabels={[
+              '1月',
+              '2月',
+              '3月',
+              '4月',
+              '5月',
+              '6月',
+              '7月',
+              '8月',
+              '9月',
+              '10月',
+              '11月',
+              '12月',
+            ]}
+            monthPlacement="top"
+            startDate={
+              year === currentYear
+                ? new Date(`${currentYear}-01-01`)
+                : new Date(`${year}-01-01`)
+            }
+            endDate={year === currentYear ? today : new Date(`${year}-12-31`)}
+            rectProps={{ rx: 3.5 }}
+            rectSize={12}
+            legendCellSize={0}
+            space={2.4}
+            panelColors={{
+              1: '#c6e48b',
+              2: '#32CD32',
+              4: '#009900',
+              6: '#006400',
+            }}
+            rectRender={(props, data) => {
+              return (
+                <Tooltip
+                  placement="top"
+                  content={`${data.count || 0} logs on ${data.date}`}
+                >
+                  <rect {...props} />
+                </Tooltip>
+              );
+            }}
+          />
+        </ScrollArea>
+      </Center>
+    </>
   );
 }

--- a/src/components/pageContent/UserPageContent.tsx
+++ b/src/components/pageContent/UserPageContent.tsx
@@ -20,7 +20,7 @@ type UserPageContentProps = {
   userData: {
     name: string;
     user_books: Record<Filter, UserBook[]>;
-    logs: Log[];
+    logs: Record<string, Log[]>;
   };
   id: string;
   isCurrentUser: boolean;

--- a/src/stories/calendar/CalendarContent.stories.ts
+++ b/src/stories/calendar/CalendarContent.stories.ts
@@ -20,15 +20,17 @@ type Story = StoryObj<typeof CalendarContent>;
 
 export const AppearenceTest: Story = {
   args: {
-    readingLogs: [
-      {
-        date: previousDay,
-        count: 1,
-      },
-      {
-        date: today,
-        count: 5,
-      },
-    ],
+    readingLogs: {
+      '2024': [
+        {
+          date: previousDay,
+          count: 1,
+        },
+        {
+          date: today,
+          count: 5,
+        },
+      ],
+    },
   },
 };


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/144

## description
今年の分しか表示されなかったため。
年度を切り替えられるように実装。

`CalendarContent`が受け取る型を`Log[]`から年をキーにした`Record<string, Log[]>`に変更し、年を選ぶMenuを追加。選択された年のログだけをヒートマップに渡すようにした。
