### PR TITLE
読書ログが全くない人がログインできない問題を修正

### DIFF
--- a/src/components/calendar/CalendarContent.tsx
+++ b/src/components/calendar/CalendarContent.tsx
@@ -20,16 +20,23 @@ export default function CalendarContent({ readingLogs }: ReadingLogs) {
   const today = new Date();
   const currentYear = String(today.getFullYear());
   const [year, setYear] = useState(currentYear);
-  const value = readingLogs[year].map((log) => ({
-    date: log.date.replaceAll('-', '/'),
-    count: log.count,
-  }));
-  const data = Object.keys(readingLogs)
-    .reverse()
-    .map((year) => ({
-      label: year,
-      target: year,
-    }));
+
+  const noLog = Object.keys(readingLogs).length === 0;
+
+  const value = noLog
+    ? []
+    : readingLogs[year].map((log) => ({
+        date: log.date.replaceAll('-', '/'),
+        count: log.count,
+      }));
+  const data = noLog
+    ? [{ label: currentYear, target: currentYear }]
+    : Object.keys(readingLogs)
+        .reverse()
+        .map((year) => ({
+          label: year,
+          target: year,
+        }));
   const selected = data.find((item) => item.target === year) || data[0];
 
   const handleClick = (item: YearItem) => {

--- a/src/stories/calendar/CalendarContent.stories.ts
+++ b/src/stories/calendar/CalendarContent.stories.ts
@@ -4,6 +4,7 @@ import CalendarContent from '@/components/calendar/CalendarContent';
 
 const previousDay = dayjs().subtract(1, 'd').format('YYYY-MM-DD');
 const today = dayjs().format('YYYY-MM-DD');
+const currentYear = String(dayjs().year());
 
 const meta: Meta<typeof CalendarContent> = {
   component: CalendarContent,
@@ -21,7 +22,7 @@ type Story = StoryObj<typeof CalendarContent>;
 export const AppearenceTest: Story = {
   args: {
     readingLogs: {
-      '2024': [
+      [currentYear]: [
         {
           date: previousDay,
           count: 1,
@@ -32,5 +33,11 @@ export const AppearenceTest: Story = {
         },
       ],
     },
+  },
+};
+
+export const NoLogTest: Story = {
+  args: {
+    readingLogs: {},
   },
 };


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/147

## description
詳細は、バックエンドのPRを参照 : 
- https://github.com/reckyy/tsundoku-backend/pull/38

バックエンドの修正に合わせて、こちらも処理を分岐。

`CalendarContent`でログが空かどうかを判定し、空の場合は当年だけを年の選択肢に出して、ヒートマップには空の配列を渡すようにした。
