### PR TITLE
SessionProviderを適切な場所に設置

### DIFF
--- a/src/components/button/DeleteAccountButton.tsx
+++ b/src/components/button/DeleteAccountButton.tsx
@@ -3,12 +3,13 @@
 import { Button, Modal } from '@mantine/core';
 import DeleteUserConfirmModal from '../modal/DeleteUserConfirmModal';
 import { useDisclosure } from '@mantine/hooks';
+import { SessionProvider } from 'next-auth/react';
 
 export default function DeleteAccountButton() {
   const [opened, { open, close }] = useDisclosure(false);
 
   return (
-    <>
+    <SessionProvider>
       <Modal
         opened={opened}
         radius="md"
@@ -21,6 +22,6 @@ export default function DeleteAccountButton() {
       <Button variant="light" radius="lg" color="red" onClick={open}>
         アカウントを削除
       </Button>
-    </>
+    </SessionProvider>
   );
 }

--- a/src/components/confirm/ConfirmDeletion.tsx
+++ b/src/components/confirm/ConfirmDeletion.tsx
@@ -12,11 +12,10 @@ import {
 } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import DeleteAccountButton from '../button/DeleteAccountButton';
-import { SessionProvider } from 'next-auth/react';
 
 export default async function ConfirmDeletion() {
   return (
-    <SessionProvider>
+    <>
       <Container my="md">
         <Title order={3} ta="center">
           アカウントを削除しますか？
@@ -43,6 +42,6 @@ export default async function ConfirmDeletion() {
           <DeleteAccountButton />
         </Center>
       </Container>
-    </SessionProvider>
+    </>
   );
 }

--- a/src/components/modal/DeleteUserConfirmModal.tsx
+++ b/src/components/modal/DeleteUserConfirmModal.tsx
@@ -1,6 +1,5 @@
 import { Text, Divider, Space, Button, Group } from '@mantine/core';
 import useDeleteUser from '@/hooks/useDeleteUser';
-import { SessionProvider } from 'next-auth/react';
 
 type DeleteUserConfirmModalParams = {
   close?: () => void;
@@ -12,7 +11,7 @@ export default function DeleteUserConfirmModal({
   const { handleDeleteUser } = useDeleteUser();
 
   return (
-    <SessionProvider>
+    <>
       <Text size="lg" fw={700} ta="center">
         本当に削除しますか？
       </Text>
@@ -34,6 +33,6 @@ export default function DeleteUserConfirmModal({
           削除
         </Button>
       </Group>
-    </SessionProvider>
+    </>
   );
 }


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/151

## description
詳細は以下。

- https://github.com/reckyy/tsundoku/issues/151#issue-2906380589

`ConfirmDeletion`と`DeleteUserConfirmModal`から`SessionProvider`を外し、実際に必要な`DeleteUserConfirmModal`の最小の親である`DeleteAccountButton`に置いた。
