### PR TITLE
データの更新方法を統一

### DIFF
--- a/src/components/bookshelf/DndList.tsx
+++ b/src/components/bookshelf/DndList.tsx
@@ -164,7 +164,7 @@ function DndListContent({ bookItems }: DndListProps) {
   ));
 
   return (
-    <SessionProvider>
+    <>
       <Modal
         opened={opened}
         radius="md"
@@ -175,6 +175,16 @@ function DndListContent({ bookItems }: DndListProps) {
         <DeleteBookConfirmModal
           userBookId={deleteParamsState.userBookId}
           close={close}
+          onSuccess={() => {
+            const handler =
+              filter === 'unread_books'
+                ? unreadBooksHandlers
+                : filter === 'reading_books'
+                  ? readingBooksHandlers
+                  : finishedBooksHandlers;
+            handler.remove(deleteParamsState.position);
+            close();
+          }}
         />
       </Modal>
       <Space h={20} />
@@ -220,6 +230,6 @@ function DndListContent({ bookItems }: DndListProps) {
           <Text ta="center">{emptyMessages[filter]}</Text>
         </>
       )}
-    </SessionProvider>
+    </>
   );
 }

--- a/src/components/modal/DeleteBookConfirmModal.tsx
+++ b/src/components/modal/DeleteBookConfirmModal.tsx
@@ -5,13 +5,15 @@ import useDeleteBook from '@/hooks/useDeleteBook';
 type DeleteBookModalProps = {
   userBookId: number;
   close: () => void;
+  onSuccess: () => void;
 };
 
 export default function DeleteBookConfirmModal({
   userBookId,
   close,
+  onSuccess,
 }: DeleteBookModalProps) {
-  const { handleDeleteBook } = useDeleteBook(userBookId);
+  const { handleDeleteBook } = useDeleteBook({ userBookId, onSuccess });
 
   return (
     <>

--- a/src/hooks/useDeleteBook.ts
+++ b/src/hooks/useDeleteBook.ts
@@ -1,10 +1,16 @@
 import toast from 'react-hot-toast';
-import { useRouter } from 'next/navigation';
 import { axiosDelete } from '@/lib/axios';
 import { useSession } from 'next-auth/react';
 
-export default function useDeleteBook(userBookId: number) {
-  const router = useRouter();
+type useDeleteBookProps = {
+  userBookId: number;
+  onSuccess: () => void;
+};
+
+export default function useDeleteBook({
+  userBookId,
+  onSuccess,
+}: useDeleteBookProps) {
   const { data: session } = useSession();
 
   const handleDeleteBook = async () => {
@@ -12,7 +18,7 @@ export default function useDeleteBook(userBookId: number) {
     try {
       const res = await axiosDelete(`/user_books/${userBookId}`, token);
       if (res.status === 204) {
-        router.refresh();
+        onSuccess();
         toast('本を削除しました。');
       } else {
         throw new Error();

--- a/src/hooks/useUpdateBookStatus.ts
+++ b/src/hooks/useUpdateBookStatus.ts
@@ -1,41 +1,17 @@
-import toast from 'react-hot-toast';
 import { useSession } from 'next-auth/react';
 import { axiosPatch } from '@/lib/axios';
-import { BookWithMemos } from '@/types/book';
 
-type useUpdateBookStatusProps = {
-  userBookId: number;
-  setBookWithMemos: React.Dispatch<
-    React.SetStateAction<BookWithMemos | undefined>
-  >;
-};
-
-export default function useUpdateBookStatus({
-  userBookId,
-  setBookWithMemos,
-}: useUpdateBookStatusProps) {
+export default function useUpdateBookStatus(userBookId?: number) {
   const { data: session } = useSession();
   const token = session?.user?.accessToken;
 
-  const handleSubmit = async (status: string) => {
-    try {
-      await axiosPatch(`/user_books/${userBookId}`, token, {
-        userBookId,
-        status,
-      });
-      setBookWithMemos((prev) => {
-        if (!prev) return prev;
-
-        return {
-          ...prev,
-          status,
-        };
-      });
-      toast.success('読書ステータスを更新しました！');
-    } catch (error) {
-      toast.error('読書ステータスの更新に失敗しました。');
-    }
+  const handleUpdateBookStatus = async (status: string) => {
+    if (!userBookId) throw new Error();
+    await axiosPatch(`/user_books/${userBookId}`, token, {
+      userBookId,
+      status,
+    });
   };
 
-  return { handleSubmit };
+  return { handleUpdateBookStatus };
 }

--- a/src/stories/modal/DeleteBookConfirmModal.stories.tsx
+++ b/src/stories/modal/DeleteBookConfirmModal.stories.tsx
@@ -33,6 +33,9 @@ const meta: Meta<typeof DeleteBookConfirmModal> = {
   },
   args: {
     userBookId: 1,
+    onSuccess: () => {
+      console.log('onSuccessが呼ばれた');
+    },
     close: () => {
       console.log('モーダルを閉じました。');
     },


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/160

## description
- https://github.com/reckyy/tsundoku/issues/160#issue-2917338779

`useDeleteBook`と`useUpdateBookStatus`が状態の更新まで担っていたのをやめ、呼び出し元の`DndList`・`DeleteBookConfirmModal`・`MemoPageContent`で更新するようにした。
