### PR TITLE
check workflowの依存インストールをnpm ciに変更

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ jobs:
         node-version: '20.9.0'
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci
 
     - name: Run ESLint
       run: npm run lint


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/258

## description
Issue側に記載。