### PR TITLE
楽天APIエンドポイントの変更

### DIFF
--- a/src/app/api/books/search/route.ts
+++ b/src/app/api/books/search/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const title = searchParams.get('title');
+  const author = searchParams.get('author');
+
+  const applicationId = process.env.RAKUTEN_API_APPLICATION_ID;
+  const accessKey = process.env.RAKUTEN_API_ACCESS_KEY;
+  const apiUrl =
+    'https://openapi.rakuten.co.jp/services/api/BooksBook/Search/20170404';
+
+  if (!applicationId || !accessKey) {
+    return NextResponse.json(
+      { error: '楽天APIの設定が不足しています。' },
+      { status: 500 },
+    );
+  }
+
+  const params: Record<string, string> = { applicationId, accessKey };
+  if (title) params.title = title;
+  if (author) params.author = author;
+
+  try {
+    const res = await axios.get(apiUrl, {
+      params,
+      headers: {
+        Origin: 'https://tsundoku.tech',
+      },
+    });
+    return NextResponse.json(res.data);
+  } catch {
+    return NextResponse.json(
+      { error: '楽天APIへのリクエストに失敗しました。' },
+      { status: 502 },
+    );
+  }
+}

--- a/src/stories/search/SearchForm.stories.ts
+++ b/src/stories/search/SearchForm.stories.ts
@@ -4,6 +4,19 @@ import { userEvent, within, expect, waitFor, screen } from '@storybook/test';
 import SearchForm from '@/components/search/SearchForm';
 import toast from 'react-hot-toast';
 
+const mockBooksResponse = {
+  Items: [
+    {
+      Item: {
+        title: '本のタイトル',
+        author: '著者名',
+        largeImageUrl:
+          'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0618/9784297140618_1_2.jpg?_ex=200x200',
+      },
+    },
+  ],
+};
+
 const meta: Meta<typeof SearchForm> = {
   component: SearchForm,
   parameters: {
@@ -46,6 +59,15 @@ export const LabelAuthorTest: Story = {
 };
 
 export const SearchTest: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/books/search', () => {
+          return HttpResponse.json(mockBooksResponse);
+        }),
+      ],
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const searchInput = canvas.getByLabelText('search');
@@ -73,12 +95,9 @@ export const ErrorTest: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get(
-          `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404`,
-          () => {
-            return HttpResponse.error();
-          },
-        ),
+        http.get(`/api/books/search`, () => {
+          return HttpResponse.error();
+        }),
       ],
     },
   },

--- a/src/stories/search/SearchHome.stories.ts
+++ b/src/stories/search/SearchHome.stories.ts
@@ -1,6 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
 import { userEvent, within, expect, waitFor } from '@storybook/test';
 import SearchHome from '@/components/search/SearchHome';
+
+const mockBooksResponse = {
+  Items: [
+    {
+      Item: {
+        title: 'プロを目指す人のためのRuby入門',
+        author: '伊藤淳一',
+        largeImageUrl:
+          'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0618/9784297140618_1_2.jpg?_ex=200x200',
+      },
+    },
+  ],
+};
 
 const meta: Meta<typeof SearchHome> = {
   component: SearchHome,
@@ -20,6 +34,15 @@ export const AppearenceTest: Story = {
 };
 
 export const SearchBookTest: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/books/search', () => {
+          return HttpResponse.json(mockBooksResponse);
+        }),
+      ],
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const searchInput = canvas.getByLabelText('search');

--- a/src/utils/searchBooks.ts
+++ b/src/utils/searchBooks.ts
@@ -48,12 +48,9 @@ export async function searchBooks({
   selected,
   onResults,
 }: SearchParams) {
-  const applicationId = process.env.NEXT_PUBLIC_RAKUTEN_API_APPLICATION_ID;
-  const apiUrl = `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404`;
+  const apiUrl = '/api/books/search';
   const params =
-    selected.label === 'title'
-      ? { applicationId, title: searchWord }
-      : { applicationId, author: searchWord };
+    selected.label === 'title' ? { title: searchWord } : { author: searchWord };
 
   try {
     const res = await axios.get(apiUrl, { params });


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/167
- https://github.com/reckyy/tsundoku/issues/219

## description
- 本検索を`/api/books/search`経由に変更
- Route Handlerで楽天APIを呼ぶように変更
- Storybookのmockを追従
