### PR TITLE
JWTの有効期限をsessionで管理し期限切れ時に無効化

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,28 +1,77 @@
-import NextAuth from 'next-auth';
+import NextAuth, { type DefaultSession } from 'next-auth';
 import Google from 'next-auth/providers/google';
 import { NextResponse } from 'next/server';
 import axios from 'axios';
 
+const THIRTY_DAYS_IN_SECONDS = 30 * 24 * 60 * 60;
+
+type BackendSignInResponse = {
+  id: string;
+  access_token: string;
+  access_token_expires_at: string;
+};
+
+type AuthToken = {
+  id?: string;
+  accessToken?: string;
+  accessTokenExpiresAt?: string;
+};
+
 declare module 'next-auth' {
+  interface Session {
+    user: DefaultSession['user'] & {
+      id?: string;
+      accessToken?: string;
+      accessTokenExpiresAt?: string;
+    };
+  }
+
   interface User {
-    accessToken: string;
+    id?: string;
+    accessToken?: string;
+    accessTokenExpiresAt?: string;
   }
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [Google],
+  session: {
+    maxAge: THIRTY_DAYS_IN_SECONDS,
+  },
   callbacks: {
     async jwt({ token, user }) {
-      if (user?.id && user?.accessToken) {
-        token.id = user.id;
-        token.accessToken = user.accessToken;
+      const authToken = token as typeof token & AuthToken;
+
+      if (user?.id && user?.accessToken && user?.accessTokenExpiresAt) {
+        authToken.id = user.id;
+        authToken.accessToken = user.accessToken;
+        authToken.accessTokenExpiresAt = user.accessTokenExpiresAt;
       }
-      return token;
+
+      if (authToken.accessToken && !authToken.accessTokenExpiresAt) {
+        return null;
+      }
+
+      if (
+        authToken.accessTokenExpiresAt &&
+        Date.now() >= Date.parse(authToken.accessTokenExpiresAt)
+      ) {
+        return null;
+      }
+
+      return authToken;
     },
     async session({ session, token }) {
-      if (token.accessToken && token.id) {
-        session.user.id = token.id as string;
-        session.user.accessToken = token.accessToken as string;
+      const authToken = token as typeof token & AuthToken;
+
+      if (
+        authToken.accessToken &&
+        authToken.id &&
+        authToken.accessTokenExpiresAt
+      ) {
+        session.user.id = authToken.id;
+        session.user.accessToken = authToken.accessToken;
+        session.user.accessTokenExpiresAt = authToken.accessTokenExpiresAt;
       }
       return session;
     },
@@ -33,7 +82,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       const avatarUrl = user.image;
       const idToken = account?.id_token;
       try {
-        const res = await axios.post(
+        const res = await axios.post<BackendSignInResponse>(
           `${process.env.NEXT_PUBLIC_RAILS_API_URL}/auth/callback/google`,
           {
             name,
@@ -44,7 +93,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         );
         if (res.status === 200) {
           user.id = res.data.id;
-          user.accessToken = res.data.access_token as string;
+          user.accessToken = res.data.access_token;
+          user.accessTokenExpiresAt = res.data.access_token_expires_at;
           return true;
         } else {
           return false;


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/189

## description
- backendから返る`access_token_expires_at`をsessionに保持
- JWTコールバックで毎回期限チェックし、期限切れならsessionを無効化
- `session.maxAge`を30日に明示
- 型定義を追加（BackendSignInResponse, AuthToken, Session/User拡張）
