### PR TITLE
Storybookのモックセッション期限を更新

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,8 +2,7 @@ import NextAuth, { type DefaultSession } from 'next-auth';
 import Google from 'next-auth/providers/google';
 import { NextResponse } from 'next/server';
 import axios from 'axios';
-
-const THIRTY_DAYS_IN_SECONDS = 30 * 24 * 60 * 60;
+import { THIRTY_DAYS_IN_SECONDS } from '@/constants/session';
 
 type BackendSignInResponse = {
   id: string;

--- a/src/constants/session.ts
+++ b/src/constants/session.ts
@@ -1,0 +1,1 @@
+export const THIRTY_DAYS_IN_SECONDS = 30 * 24 * 60 * 60;

--- a/src/stories/button/AddBookButton.stories.tsx
+++ b/src/stories/button/AddBookButton.stories.tsx
@@ -3,18 +3,15 @@ import { http, HttpResponse } from 'msw';
 import { userEvent, within, expect, waitFor } from '@storybook/test';
 import AddBookButton from '@/components/button/AddBookButton';
 import { SessionProvider } from 'next-auth/react';
-import { Session } from 'next-auth';
+import { createMockSession } from '@/stories/utils/mockSession';
 
 const RAILS_API_URL = process.env.STORYBOOK_NEXT_PUBLIC_RAILS_API_URL;
 
-const mockSession: Session = {
-  user: {
-    name: 'Test User',
-    email: 'testuser@example.com',
-    accessToken: 'hogehoge',
-  },
-  expires: '2025-12-31T23:59:59.999Z',
-};
+const mockSession = createMockSession({
+  name: 'Test User',
+  email: 'testuser@example.com',
+  accessToken: 'hogehoge',
+});
 
 const meta: Meta<typeof AddBookButton> = {
   component: AddBookButton,

--- a/src/stories/modal/DeleteBookConfirmModal.stories.tsx
+++ b/src/stories/modal/DeleteBookConfirmModal.stories.tsx
@@ -3,18 +3,15 @@ import { http, HttpResponse } from 'msw';
 import { userEvent, within, expect, waitFor } from '@storybook/test';
 import DeleteBookConfirmModal from '@/components/modal/DeleteBookConfirmModal';
 import { SessionProvider } from 'next-auth/react';
-import { Session } from 'next-auth';
+import { createMockSession } from '@/stories/utils/mockSession';
 
 const RAILS_API_URL = process.env.STORYBOOK_NEXT_PUBLIC_RAILS_API_URL;
 
-const mockSession: Session = {
-  user: {
-    name: 'Test User',
-    email: 'testuser@example.com',
-    accessToken: 'hogehoge',
-  },
-  expires: '2025-12-31T23:59:59.999Z',
-};
+const mockSession = createMockSession({
+  name: 'Test User',
+  email: 'testuser@example.com',
+  accessToken: 'hogehoge',
+});
 
 const meta: Meta<typeof DeleteBookConfirmModal> = {
   component: DeleteBookConfirmModal,

--- a/src/stories/modal/DeleteUserConfirmModal.stories.tsx
+++ b/src/stories/modal/DeleteUserConfirmModal.stories.tsx
@@ -3,19 +3,16 @@ import { http, HttpResponse } from 'msw';
 import { userEvent, within, expect, waitFor } from '@storybook/test';
 import DeleteUserConfirmModal from '@/components/modal/DeleteUserConfirmModal';
 import { SessionProvider } from 'next-auth/react';
-import { Session } from 'next-auth';
+import { createMockSession } from '@/stories/utils/mockSession';
 
 const RAILS_API_URL = process.env.STORYBOOK_NEXT_PUBLIC_RAILS_API_URL;
 
-const mockSession: Session = {
-  user: {
-    id: '1',
-    name: 'Test User',
-    email: 'testuser@example.com',
-    accessToken: 'hogehoge',
-  },
-  expires: '2025-12-31T23:59:59.999Z',
-};
+const mockSession = createMockSession({
+  id: '1',
+  name: 'Test User',
+  email: 'testuser@example.com',
+  accessToken: 'hogehoge',
+});
 
 const meta: Meta<typeof DeleteUserConfirmModal> = {
   component: DeleteUserConfirmModal,

--- a/src/stories/pageContent/MemoPageContent.stories.tsx
+++ b/src/stories/pageContent/MemoPageContent.stories.tsx
@@ -3,23 +3,20 @@ import { http, HttpResponse } from 'msw';
 import { userEvent, within, expect, waitFor, screen } from '@storybook/test';
 import MemoPageContent from '@/components/pageContent/MemoPageContent';
 import { SessionProvider } from 'next-auth/react';
-import { Session } from 'next-auth';
 import * as nextNavigation from 'next/navigation';
+import { createMockSession } from '@/stories/utils/mockSession';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (nextNavigation as any).useParams = () => ({
   bookId: '1',
 });
 
-const mockSession: Session = {
-  user: {
-    id: '1',
-    name: 'Test User',
-    email: 'testuser@example.com',
-    accessToken: 'hogehoge',
-  },
-  expires: '2025-12-31T23:59:59.999Z',
-};
+const mockSession = createMockSession({
+  id: '1',
+  name: 'Test User',
+  email: 'testuser@example.com',
+  accessToken: 'hogehoge',
+});
 
 const RAILS_API_URL = process.env.STORYBOOK_NEXT_PUBLIC_RAILS_API_URL;
 

--- a/src/stories/utils/mockSession.ts
+++ b/src/stories/utils/mockSession.ts
@@ -1,0 +1,9 @@
+import { Session } from 'next-auth';
+import { THIRTY_DAYS_IN_SECONDS } from '@/constants/session';
+
+type MockSessionUser = NonNullable<Session['user']>;
+
+export const createMockSession = (user: MockSessionUser): Session => ({
+  user,
+  expires: new Date(Date.now() + THIRTY_DAYS_IN_SECONDS * 1000).toISOString(),
+});


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/215

## description
セッション期限をハードコーディングしていた。
共通helperを作成し、常時デフォルトの30日後に設定。