### PR TITLE
本の追加時に冗長なPOST /books呼び出しを削除

### DIFF
--- a/src/hooks/useAddBook.ts
+++ b/src/hooks/useAddBook.ts
@@ -11,11 +11,6 @@ export default function useAddBook(book: Book) {
   const handleSubmit = async () => {
     const token = session?.user?.accessToken;
     try {
-      await axiosPost('/books', token, {
-        title: book.title,
-        author: book.author,
-        coverImageUrl: book.coverImageUrl,
-      });
       await axiosPost('/user_books', token, {
         title: book.title,
         author: book.author,


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/182

## description
backendの処理簡素化に伴い、冗長な呼び出しを削除。
詳細は、下記コメントやdiffを参照。
- https://github.com/reckyy/tsundoku-backend/pull/57