### PR TITLE
退会後のthanksページへの遷移をsignOutに一本化

### DIFF
--- a/src/hooks/useDeleteUser.ts
+++ b/src/hooks/useDeleteUser.ts
@@ -1,11 +1,9 @@
-import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { signOut } from 'next-auth/react';
 import { axiosDelete } from '@/lib/axios';
 import { useSession } from 'next-auth/react';
 
 export default function useDeleteUser() {
-  const router = useRouter();
   const { data: session } = useSession();
 
   const handleDeleteUser = async () => {
@@ -13,10 +11,7 @@ export default function useDeleteUser() {
     try {
       const res = await axiosDelete(`/users/${session?.user?.id}`, token);
       if (res.status === 204) {
-        signOut();
-        router.push('/thanks');
-        router.refresh();
-        toast.success('アカウントを削除しました。');
+        await signOut({ callbackUrl: '/thanks' });
       } else {
         throw new Error();
       }


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/221

## description
退会完了前に、`router.push('/thanks')`が実行されて、`thanks`ページに遷移せず表示されなかった問題を解消。