### PR TITLE
Editorコンポーネントから未使用のheadingId propsを削除

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -18,7 +18,6 @@ import classes from './Editor.module.css';
 
 type EditorProps = {
   heading: Heading | undefined;
-  headingId: number;
   handleSaveAll: (
     title: string,
     headingId: number,

--- a/src/components/pageContent/MemoPageContent.tsx
+++ b/src/components/pageContent/MemoPageContent.tsx
@@ -277,7 +277,6 @@ export default function MemoPageContent() {
         <Space h={50} />
         <Editor
           heading={bookWithMemos?.headings[Number(heading) - 1]}
-          headingId={bookWithMemos?.headings[Number(heading) - 1].id}
           handleSaveAll={handleSaveAll}
         />
       </Container>


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/205

## description
Issueの概要通り。
なお`handleSaveAll`のコールバック引数`headingId: number`は関数のシグネチャとして必要なので残している。