### PR TITLE
検索結果カードのUI重複をSearchResultCardに抽出

### DIFF
--- a/src/components/search/Results.tsx
+++ b/src/components/search/Results.tsx
@@ -1,14 +1,5 @@
-import {
-  Image,
-  Card,
-  SimpleGrid,
-  Text,
-  Grid,
-  GridCol,
-  Flex,
-  Center,
-} from '@mantine/core';
-import AddBookButton from '../button/AddBookButton';
+import { Grid, GridCol, Center } from '@mantine/core';
+import SearchResultCard from './SearchResultCard';
 import { Book } from '@/types/index';
 import { SessionProvider } from 'next-auth/react';
 
@@ -19,50 +10,13 @@ export default function Results({ bookItems }: { bookItems: Book[] }) {
         <Grid justify="center" align="stretch">
           {bookItems.map((book) => (
             <GridCol span={6} key={book.id}>
-              <Card padding="md" withBorder shadow="sm" radius="md">
-                <SimpleGrid cols={{ base: 1, sm: 2 }}>
-                  <Image
-                    radius="lg"
-                    w={141}
-                    h={200}
-                    fit="contain"
-                    src={book.coverImageUrl}
-                    alt={book.title}
-                  />
-                  <Flex
-                    gap="sm"
-                    justify="center"
-                    align="center"
-                    direction="column"
-                  >
-                    <Text lineClamp={2}>{book.title}</Text>
-                    <Text lineClamp={1}>{book.author}</Text>
-                    <AddBookButton book={book} />
-                  </Flex>
-                </SimpleGrid>
-              </Card>
+              <SearchResultCard book={book} />
             </GridCol>
           ))}
         </Grid>
       ) : (
         <Center>
-          <Card padding="md" withBorder shadow="sm" radius="md">
-            <SimpleGrid cols={{ base: 1, sm: 2 }}>
-              <Image
-                radius="lg"
-                w={141}
-                h={200}
-                fit="contain"
-                src={bookItems[0].coverImageUrl}
-                alt={bookItems[0].title}
-              />
-              <Flex gap="sm" justify="center" align="center" direction="column">
-                <Text lineClamp={2}>{bookItems[0].title}</Text>
-                <Text lineClamp={1}>{bookItems[0].author}</Text>
-                <AddBookButton book={bookItems[0]} />
-              </Flex>
-            </SimpleGrid>
-          </Card>
+          <SearchResultCard book={bookItems[0]} />
         </Center>
       )}
     </SessionProvider>

--- a/src/components/search/SearchResultCard.tsx
+++ b/src/components/search/SearchResultCard.tsx
@@ -1,0 +1,25 @@
+import { Image, Card, SimpleGrid, Text, Flex } from '@mantine/core';
+import AddBookButton from '../button/AddBookButton';
+import { Book } from '@/types/index';
+
+export default function SearchResultCard({ book }: { book: Book }) {
+  return (
+    <Card padding="md" withBorder shadow="sm" radius="md">
+      <SimpleGrid cols={{ base: 1, sm: 2 }}>
+        <Image
+          radius="lg"
+          w={141}
+          h={200}
+          fit="contain"
+          src={book.coverImageUrl}
+          alt={book.title}
+        />
+        <Flex gap="sm" justify="center" align="center" direction="column">
+          <Text lineClamp={2}>{book.title}</Text>
+          <Text lineClamp={1}>{book.author}</Text>
+          <AddBookButton book={book} />
+        </Flex>
+      </SimpleGrid>
+    </Card>
+  );
+}

--- a/src/stories/search/SearchResultCard.stories.tsx
+++ b/src/stories/search/SearchResultCard.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import SearchResultCard from '@/components/search/SearchResultCard';
+import { SessionProvider } from 'next-auth/react';
+import { createMockSession } from '@/stories/utils/mockSession';
+
+const mockSession = createMockSession({
+  name: 'Test User',
+  email: 'testuser@example.com',
+  accessToken: 'hogehoge',
+});
+
+const meta: Meta<typeof SearchResultCard> = {
+  component: SearchResultCard,
+  decorators: [
+    (Story) => (
+      <SessionProvider session={mockSession}>
+        <Story />
+      </SessionProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  args: {
+    book: {
+      id: 1,
+      title: '実践Next.js -- App Routerで進化するWebアプリ開発',
+      author: '吉井 健文',
+      coverImageUrl:
+        'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0618/9784297140618_1_2.jpg?_ex=200x200',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SearchResultCard>;
+
+export const AppearenceTest: Story = {};


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/203

## description
- `Results.tsx` : 重複していた検索結果カードのUI（Card + Image + テキスト + AddBookButton）を`SearchResultCard.tsx`に共通コンポーネントとして抽出
