### PR TITLE
backendのステータスコード変更に追従

### DIFF
--- a/src/hooks/useAddHeading.ts
+++ b/src/hooks/useAddHeading.ts
@@ -16,7 +16,7 @@ export default function useAddHeading() {
         userBookId: bookWithMemos.id,
         number,
       });
-      if (res.status === 200) {
+      if (res.status === 201) {
         toast.success('章を追加しました。');
         return {
           id: res.data.id,


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/175

## description
backendで、`POST /api/headings`の成功ステータスが200→201に変更されたため、それに追従させた。
他のAPI呼び出しは明示的なステータス比較を行なっていないため、修正していない。