### PR TITLE
MemoPageContentをSWRのmutateベースに書き換え

### DIFF
--- a/src/components/pageContent/MemoPageContent.tsx
+++ b/src/components/pageContent/MemoPageContent.tsx
@@ -92,29 +92,44 @@ export default function MemoPageContent() {
   const { data: session } = useSession();
   const token = session?.user?.accessToken;
   const { handleAddHeading } = useAddHeading();
-  const [bookWithMemos, setBookWithMemos] = useState<BookWithMemos>();
   const [heading, setHeading] = useState('1');
-  const { handleUpdateBookStatus } = useUpdateBookStatus(bookWithMemos?.id);
 
   async function fetcher(url: string) {
     const res = await axiosGet(url, token);
     return res.data;
   }
 
-  const { error, isLoading } = useSWR(
+  const {
+    data: bookWithMemos,
+    error,
+    isLoading,
+    mutate,
+  } = useSWR<BookWithMemos>(
     token ? `/memos/?bookId=${bookId}` : null,
     fetcher,
     {
-      onSuccess: (data) => {
-        setBookWithMemos(data);
-      },
+      revalidateOnFocus: false,
     },
   );
 
+  const { handleUpdateBookStatus } = useUpdateBookStatus(bookWithMemos?.id);
+
   const handleStatusChange = async (status: string) => {
+    if (!bookWithMemos) return;
+    const optimisticData: BookWithMemos = { ...bookWithMemos, status };
     try {
-      await handleUpdateBookStatus(status);
-      setBookWithMemos((prev) => (prev ? { ...prev, status } : prev));
+      await mutate(
+        async () => {
+          await handleUpdateBookStatus(status);
+          return optimisticData;
+        },
+        {
+          optimisticData,
+          rollbackOnError: true,
+          populateCache: true,
+          revalidate: false,
+        },
+      );
       toast.success('読書ステータスを更新しました！');
     } catch {
       toast.error('読書ステータスの更新に失敗しました。');
@@ -127,35 +142,36 @@ export default function MemoPageContent() {
     content: string,
     memoId: number,
   ) => {
-    if (!token) {
+    if (!token || !bookWithMemos) {
       return false;
     }
 
+    const optimisticData: BookWithMemos = {
+      ...bookWithMemos,
+      headings: bookWithMemos.headings.map((h) =>
+        h.id === headingId
+          ? { ...h, title, memo: { ...h.memo, body: content } }
+          : h,
+      ),
+    };
+
     try {
-      await Promise.all([
-        saveData({ token, id: headingId, data: title, type: 'heading' }),
-        saveData({ token, id: memoId, data: content, type: 'memo' }),
-      ]);
-
-      setBookWithMemos((prev) => {
-        if (!prev) return prev;
-        return {
-          ...prev,
-          headings: prev.headings.map((h) =>
-            h.id === headingId
-              ? {
-                  ...h,
-                  title,
-                  memo: {
-                    ...h.memo,
-                    body: content,
-                  },
-                }
-              : h,
-          ),
-        };
-      });
-
+      await mutate(
+        async () => {
+          const [okHeading, okMemo] = await Promise.all([
+            saveData({ token, id: headingId, data: title, type: 'heading' }),
+            saveData({ token, id: memoId, data: content, type: 'memo' }),
+          ]);
+          if (!okHeading || !okMemo) throw new Error('save failed');
+          return optimisticData;
+        },
+        {
+          optimisticData,
+          rollbackOnError: true,
+          populateCache: true,
+          revalidate: false,
+        },
+      );
       toast.success('保存しました。');
     } catch (error) {
       console.warn(error);
@@ -175,13 +191,13 @@ export default function MemoPageContent() {
     );
 
     if (newHeading) {
-      setBookWithMemos((prev) => {
-        if (!prev) return prev;
-        return {
-          ...prev,
-          headings: [...prev.headings, newHeading],
-        };
-      });
+      await mutate(
+        (current) =>
+          current
+            ? { ...current, headings: [...current.headings, newHeading] }
+            : current,
+        { revalidate: false },
+      );
     }
   };
 

--- a/src/stories/pageContent/MemoPageContent.stories.tsx
+++ b/src/stories/pageContent/MemoPageContent.stories.tsx
@@ -183,7 +183,7 @@ export const AddMemoTest: Story = {
         http.patch(`${RAILS_API_URL}/headings/1`, () => {
           return new HttpResponse();
         }),
-        http.patch(`${RAILS_API_URL}/headings/1`, () => {
+        http.patch(`${RAILS_API_URL}/memos/1`, () => {
           return new HttpResponse();
         }),
         http.post(`${RAILS_API_URL}/reading_logs`, () => {


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/218

## description
`MemoPageContent.tsx`のSWRデータを`useState`にコピーするアンチパターンを排除し、`useSWR`の`data`をもとに`mutate`ベースの楽観的更新へ変更。

### SWRを維持する判断
同ページ内でしか使わないためSWR撤去すべきか検討したが、以下を理由に維持。
- `mutate`APIによる楽観的更新 + 自動ロールバックがそのまま使える
- ローディング・エラー状態管理、リクエスト重複排除などの記述不要

### 各 `mutate` オプションの意図

| オプション | 値 | 意図 |
| --- | --- | --- |
| `optimisticData` | 楽観的に更新後の状態 | 即時 UI 反映 |
| `rollbackOnError` | `true` | API 失敗時に自動でキャッシュを元に戻す |
| `populateCache` | `true` | 成功時に updater の戻り値でキャッシュを上書き |
| `revalidate` | `false` | mutate 後に GET を発火させない |

`rebalidate: false`を必須にしているのは、MSWテストの`GET /memos`が常に同じ初期データを返すため、章追加後に再検証すると新章が消えて`AddHeadingTest`の3章アサートが失敗するため。
本番でも、章追加後にGETが走るとサーバ反映前のレスポンスが来て一瞬見える可能性がある。

### `revalidateOnFocus`を`useSWR`に追加
直接の目的は楽観的更新がフォーカス時GETで踏み潰されるのを防ぐため。
副次効果として、タブ切り替えで未保存メモが消える既存バグも解消。
「他デバイスで同じ本を編集した場合、戻ってきても自動で最新を取り直さない」性質はつくが、許容範囲と判断。