### PR TITLE
Header.tsxの非nullアサーションをガード付きに修正

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -20,11 +20,11 @@ export async function Header() {
             </Group>
           </Link>
           <Group ml="xl">
-            {session?.user && (
+            {session?.user?.id && (
               <UserMenu
-                name={session.user.name!}
-                id={session.user.id!}
-                image={session.user.image!}
+                name={session.user.name ?? 'ユーザー'}
+                id={session.user.id}
+                image={session.user.image ?? undefined}
               />
             )}
           </Group>

--- a/src/components/header/UserMenu.tsx
+++ b/src/components/header/UserMenu.tsx
@@ -24,7 +24,7 @@ import Link from 'next/link';
 type UserMenuProps = {
   name: string;
   id: string;
-  image: string;
+  image?: string;
 };
 
 export default function UserMenu({ name, id, image }: UserMenuProps) {


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/206

## description
`id`はUserMenuの動作に必須なので、ガードで条件分岐し、`name`と`image`はfallbackで対応する。