### PR TITLE
散在していたSessionProviderを(authenticated)/layout.tsxに集約

### DIFF
--- a/src/app/(authenticated)/books/[bookId]/memos/page.tsx
+++ b/src/app/(authenticated)/books/[bookId]/memos/page.tsx
@@ -1,12 +1,5 @@
-'use client';
-
 import MemoPageContent from '@/components/pageContent/MemoPageContent';
-import { SessionProvider } from 'next-auth/react';
 
 export default function Page() {
-  return (
-    <SessionProvider>
-      <MemoPageContent />
-    </SessionProvider>
-  );
+  return <MemoPageContent />;
 }

--- a/src/app/(authenticated)/layout.tsx
+++ b/src/app/(authenticated)/layout.tsx
@@ -1,0 +1,6 @@
+import type { PropsWithChildren } from 'react';
+import { AuthSessionProvider } from '@/components/auth/AuthSessionProvider';
+
+export default function AuthenticatedLayout({ children }: PropsWithChildren) {
+  return <AuthSessionProvider>{children}</AuthSessionProvider>;
+}

--- a/src/components/auth/AuthSessionProvider.tsx
+++ b/src/components/auth/AuthSessionProvider.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+import type { PropsWithChildren } from 'react';
+
+export const AuthSessionProvider = ({ children }: PropsWithChildren) => {
+  return <SessionProvider>{children}</SessionProvider>;
+};

--- a/src/components/bookshelf/DndList.tsx
+++ b/src/components/bookshelf/DndList.tsx
@@ -21,21 +21,13 @@ import BookFilterSegmentedControl, {
 import toast from 'react-hot-toast';
 import { useState } from 'react';
 import { axiosPatch } from '@/lib/axios';
-import { useSession, SessionProvider } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 
 export type DndListProps = {
   bookItems: Record<Filter, UserBook[]>;
 };
 
 export default function DndList({ bookItems }: DndListProps) {
-  return (
-    <SessionProvider>
-      <DndListContent bookItems={bookItems} />
-    </SessionProvider>
-  );
-}
-
-function DndListContent({ bookItems }: DndListProps) {
   const [source, setSource] = useState<number>(0);
   const [unreadBooks, unreadBooksHandlers] = useListState<UserBook>(
     bookItems['unread_books'],

--- a/src/components/button/DeleteAccountButton.tsx
+++ b/src/components/button/DeleteAccountButton.tsx
@@ -3,13 +3,12 @@
 import { Button, Modal } from '@mantine/core';
 import DeleteUserConfirmModal from '../modal/DeleteUserConfirmModal';
 import { useDisclosure } from '@mantine/hooks';
-import { SessionProvider } from 'next-auth/react';
 
 export default function DeleteAccountButton() {
   const [opened, { open, close }] = useDisclosure(false);
 
   return (
-    <SessionProvider>
+    <>
       <Modal
         opened={opened}
         radius="md"
@@ -22,6 +21,6 @@ export default function DeleteAccountButton() {
       <Button variant="light" radius="lg" color="red" onClick={open}>
         アカウントを削除
       </Button>
-    </SessionProvider>
+    </>
   );
 }

--- a/src/components/search/Results.tsx
+++ b/src/components/search/Results.tsx
@@ -1,24 +1,19 @@
 import { Grid, GridCol, Center } from '@mantine/core';
 import SearchResultCard from './SearchResultCard';
 import { Book } from '@/types/index';
-import { SessionProvider } from 'next-auth/react';
 
 export default function Results({ bookItems }: { bookItems: Book[] }) {
-  return (
-    <SessionProvider>
-      {bookItems.length > 1 ? (
-        <Grid justify="center" align="stretch">
-          {bookItems.map((book) => (
-            <GridCol span={6} key={book.id}>
-              <SearchResultCard book={book} />
-            </GridCol>
-          ))}
-        </Grid>
-      ) : (
-        <Center>
-          <SearchResultCard book={bookItems[0]} />
-        </Center>
-      )}
-    </SessionProvider>
+  return bookItems.length > 1 ? (
+    <Grid justify="center" align="stretch">
+      {bookItems.map((book) => (
+        <GridCol span={6} key={book.id}>
+          <SearchResultCard book={book} />
+        </GridCol>
+      ))}
+    </Grid>
+  ) : (
+    <Center>
+      <SearchResultCard book={bookItems[0]} />
+    </Center>
   );
 }


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/208

## description
`(authenticated)`route group配下に`layout.tsx`を作成し、`SessionProvider`を1箇所だけ配置する形にリファクタした。

### memo
- ルートではなく、上記配置にしたのは`(shared)`パブリックルートに波及させないため
- `use client`を使う部分は`AuthSessionProvider`の1ファイルに閉じ込めた