### PR TITLE
エラーハンドリングを統一

### DIFF
--- a/src/components/bookshelf/DndList.tsx
+++ b/src/components/bookshelf/DndList.tsx
@@ -100,6 +100,7 @@ export default function DndList({ bookItems }: DndListProps) {
       handler.swap({ from: source, to: index });
       toast.success('本の並び替えに成功しました！');
     } catch (error) {
+      console.warn(error);
       toast.error('本の並び替えに失敗しました。');
     }
   };

--- a/src/components/pageContent/MemoPageContent.tsx
+++ b/src/components/pageContent/MemoPageContent.tsx
@@ -131,7 +131,8 @@ export default function MemoPageContent() {
         },
       );
       toast.success('読書ステータスを更新しました！');
-    } catch {
+    } catch (error) {
+      console.warn(error);
       toast.error('読書ステータスの更新に失敗しました。');
     }
   };

--- a/src/hooks/useAddBook.ts
+++ b/src/hooks/useAddBook.ts
@@ -20,6 +20,7 @@ export default function useAddBook(book: Book) {
       router.refresh();
       toast.success('本を保存しました！');
     } catch (error) {
+      console.warn(error);
       toast.error('本の保存に失敗しました。');
     }
   };

--- a/src/hooks/useDeleteBook.ts
+++ b/src/hooks/useDeleteBook.ts
@@ -24,6 +24,7 @@ export default function useDeleteBook({
         throw new Error();
       }
     } catch (error) {
+      console.warn(error);
       toast.error('本の削除に失敗しました。');
     }
   };

--- a/src/hooks/useDeleteUser.ts
+++ b/src/hooks/useDeleteUser.ts
@@ -16,6 +16,7 @@ export default function useDeleteUser() {
         throw new Error();
       }
     } catch (error) {
+      console.warn(error);
       toast.error('退会に失敗しました。');
     }
   };

--- a/src/utils/searchBooks.ts
+++ b/src/utils/searchBooks.ts
@@ -62,6 +62,7 @@ export async function searchBooks({
     }));
     onResults(books);
   } catch (error) {
+    console.warn(error);
     toast.error('本の検索に失敗しました。');
   }
 }


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/204

## description
クライアント側で`try/catch`する処理は、catchブロックを以下の形にそろえた。
```ts
catch (error) {
  cosole.warn(error)
  toast.error('〜に失敗しました。')
}
```