### PR TITLE
DndListのkeyにindexではなくitem.idを使用するよう修正

### DIFF
--- a/src/components/bookshelf/DndList.tsx
+++ b/src/components/bookshelf/DndList.tsx
@@ -109,7 +109,7 @@ export default function DndList({ bookItems }: DndListProps) {
     <div
       className="cursor-grab"
       draggable
-      key={index}
+      key={item.id}
       onDragStart={() => handleDragStart(index)}
       onDragOver={handleDragOver}
       onDrop={() => handleDragEnd(index)}


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/207

## description
Reactのアンチパターンを採用してしまっていた。
現在は子要素にstateがなく、削除も`indexOf`で動的に位置取得しているため、挙動は問題ない。
ただ無駄なDOM更新が起きていることは事実なので、修正した。
参考 : https://ja.react.dev/learn/rendering-lists#why-does-react-need-keys