### PR TITLE
UserMenuのアカウント削除リンクを絶対パスに修正

### DIFF
--- a/src/components/header/UserMenu.tsx
+++ b/src/components/header/UserMenu.tsx
@@ -89,7 +89,7 @@ export default function UserMenu({ name, id, image }: UserMenuProps) {
         <Menu.Divider />
 
         <Menu.Label>Danger zone</Menu.Label>
-        <Link href="confirm_deletion">
+        <Link href="/confirm_deletion">
           <Menu.Item
             color="red"
             leftSection={

--- a/src/stories/header/UserMenu.stories.ts
+++ b/src/stories/header/UserMenu.stories.ts
@@ -33,6 +33,10 @@ export const MenuTest: Story = {
       expect(screen.getByText('公開ページ')).toBeInTheDocument();
       expect(screen.getByText('アカウントの削除')).toBeInTheDocument();
     });
+    expect(screen.getByText('アカウントの削除').closest('a')).toHaveAttribute(
+      'href',
+      '/confirm_deletion',
+    );
     await userEvent.click(userMenuButton);
     await waitFor(() => {
       expect(screen.queryByText('ログアウト')).toBeFalsy();


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/232