### PR TITLE
追加・削除・退会ボタンに二重送信防止(loading状態)を追加

### DIFF
--- a/src/components/button/AddBookButton.tsx
+++ b/src/components/button/AddBookButton.tsx
@@ -4,7 +4,7 @@ import { IconBookUpload } from '@tabler/icons-react';
 import useAddBook from '@/hooks/useAddBook';
 
 export default function AddBookButton({ book }: { book: Book }) {
-  const { handleSubmit } = useAddBook(book);
+  const { handleSubmit, isSubmitting } = useAddBook(book);
 
   return (
     <>
@@ -13,6 +13,7 @@ export default function AddBookButton({ book }: { book: Book }) {
         rightSection={<IconBookUpload size={14} />}
         variant="light"
         onClick={handleSubmit}
+        loading={isSubmitting}
       >
         本棚に追加
       </Button>

--- a/src/components/modal/DeleteBookConfirmModal.tsx
+++ b/src/components/modal/DeleteBookConfirmModal.tsx
@@ -13,7 +13,10 @@ export default function DeleteBookConfirmModal({
   close,
   onSuccess,
 }: DeleteBookModalProps) {
-  const { handleDeleteBook } = useDeleteBook({ userBookId, onSuccess });
+  const { handleDeleteBook, isSubmitting } = useDeleteBook({
+    userBookId,
+    onSuccess,
+  });
 
   return (
     <>
@@ -35,6 +38,7 @@ export default function DeleteBookConfirmModal({
           color="red"
           leftSection={<IconTrash size={14} />}
           onClick={handleDeleteBook}
+          loading={isSubmitting}
         >
           削除
         </Button>

--- a/src/components/modal/DeleteUserConfirmModal.tsx
+++ b/src/components/modal/DeleteUserConfirmModal.tsx
@@ -8,7 +8,7 @@ type DeleteUserConfirmModalParams = {
 export default function DeleteUserConfirmModal({
   close,
 }: DeleteUserConfirmModalParams) {
-  const { handleDeleteUser } = useDeleteUser();
+  const { handleDeleteUser, isSubmitting } = useDeleteUser();
 
   return (
     <>
@@ -29,6 +29,7 @@ export default function DeleteUserConfirmModal({
           radius="lg"
           color="red"
           onClick={handleDeleteUser}
+          loading={isSubmitting}
         >
           削除
         </Button>

--- a/src/hooks/useAddBook.ts
+++ b/src/hooks/useAddBook.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { useSession } from 'next-auth/react';
@@ -7,8 +8,11 @@ import { apiPost } from '@/lib/api/client';
 export default function useAddBook(book: Book) {
   const { data: session } = useSession();
   const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     const token = session?.user?.accessToken;
     try {
       await apiPost('/user_books', token, {
@@ -22,8 +26,9 @@ export default function useAddBook(book: Book) {
     } catch (error) {
       console.warn(error);
       toast.error('本の保存に失敗しました。');
+      setIsSubmitting(false);
     }
   };
 
-  return { handleSubmit };
+  return { handleSubmit, isSubmitting };
 }

--- a/src/hooks/useDeleteBook.ts
+++ b/src/hooks/useDeleteBook.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { apiDelete } from '@/lib/api/client';
 import { useSession } from 'next-auth/react';
@@ -12,8 +13,11 @@ export default function useDeleteBook({
   onSuccess,
 }: useDeleteBookProps) {
   const { data: session } = useSession();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleDeleteBook = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     const token = session?.user?.accessToken;
     try {
       await apiDelete(`/user_books/${userBookId}`, token);
@@ -22,8 +26,9 @@ export default function useDeleteBook({
     } catch (error) {
       console.warn(error);
       toast.error('本の削除に失敗しました。');
+      setIsSubmitting(false);
     }
   };
 
-  return { handleDeleteBook };
+  return { handleDeleteBook, isSubmitting };
 }

--- a/src/hooks/useDeleteUser.ts
+++ b/src/hooks/useDeleteUser.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { signOut } from 'next-auth/react';
 import { apiDelete } from '@/lib/api/client';
@@ -5,8 +6,11 @@ import { useSession } from 'next-auth/react';
 
 export default function useDeleteUser() {
   const { data: session } = useSession();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleDeleteUser = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     const token = session?.user?.accessToken;
     try {
       await apiDelete(`/users/${session?.user?.id}`, token);
@@ -14,8 +18,9 @@ export default function useDeleteUser() {
     } catch (error) {
       console.warn(error);
       toast.error('退会に失敗しました。');
+      setIsSubmitting(false);
     }
   };
 
-  return { handleDeleteUser };
+  return { handleDeleteUser, isSubmitting };
 }

--- a/src/stories/button/AddBookButton.stories.tsx
+++ b/src/stories/button/AddBookButton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { http, HttpResponse } from 'msw';
+import { http, HttpResponse, delay } from 'msw';
 import { userEvent, within, expect, waitFor } from '@storybook/test';
 import AddBookButton from '@/components/button/AddBookButton';
 import { SessionProvider } from 'next-auth/react';
@@ -61,6 +61,28 @@ export const AddBookTest: Story = {
           return new HttpResponse();
         }),
         http.post(`${RAILS_API_URL}/user_books`, () => {
+          return new HttpResponse();
+        }),
+      ],
+    },
+  },
+};
+
+export const PreventDoubleSubmitTest: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: '本棚に追加' });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.post(`${RAILS_API_URL}/user_books`, async () => {
+          await delay('infinite');
           return new HttpResponse();
         }),
       ],

--- a/src/stories/modal/DeleteBookConfirmModal.stories.tsx
+++ b/src/stories/modal/DeleteBookConfirmModal.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { http, HttpResponse } from 'msw';
+import { http, HttpResponse, delay } from 'msw';
 import { userEvent, within, expect, waitFor } from '@storybook/test';
 import DeleteBookConfirmModal from '@/components/modal/DeleteBookConfirmModal';
 import { SessionProvider } from 'next-auth/react';
@@ -82,6 +82,28 @@ export const DeleteBookFailedTest: Story = {
       handlers: [
         http.delete(`${RAILS_API_URL}/user_books/1`, () => {
           return new HttpResponse('failed', { status: 420 });
+        }),
+      ],
+    },
+  },
+};
+
+export const PreventDoubleSubmitTest: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: '削除' });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.delete(`${RAILS_API_URL}/user_books/1`, async () => {
+          await delay('infinite');
+          return new HttpResponse(null, { status: 204 });
         }),
       ],
     },

--- a/src/stories/modal/DeleteUserConfirmModal.stories.tsx
+++ b/src/stories/modal/DeleteUserConfirmModal.stories.tsx
@@ -96,3 +96,25 @@ export const DeleteUserFailedTest: Story = {
     },
   },
 };
+
+export const PreventDoubleSubmitTest: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: '削除' });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.delete(`${RAILS_API_URL}/users/1`, async () => {
+          await delay('infinite');
+          return new HttpResponse(null, { status: 204 });
+        }),
+      ],
+    },
+  },
+};


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/233

## description
下記ボタンに`isSubmitting`を追加し、送信中は早期returnでガード。
- `useAddBook`
- `useDeleteBook`
- `useDeleteUser`

成功時は画面遷移・モーダルが閉じるまで無効を維持し、失敗時のみ再押下可能にした。