### PR TITLE
Rails APIへの送信を検証用のidTokenのみに簡素化

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -76,15 +76,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     },
 
     async signIn({ user, account }) {
-      const name = user.name;
-      const email = user.email;
-      const avatarUrl = user.image;
       const idToken = account?.id_token;
       try {
         const data = (await apiPost('/auth/callback/google', undefined, {
-          name,
-          email,
-          avatarUrl,
           idToken,
         })) as BackendSignInResponse;
         user.id = data.id;


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/234

## description
上記IssueのBackendの変更に伴い、クライアントから送信するidToken以外の情報が不要になったため、`signIn`コールバックから`name / email / avatarUrl`の送信を削除し、`idToken`のみ送るようにした。

⚠️必ずBackend側のPRがマージ・デプロイされた後にマージを行う！（旧Backend + 本変更の組み合わせは全て422でログインが失敗する。）