### PR TITLE
CIにStorybook test-runnerを追加

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,6 @@
 next.config.mjs
 tailwind.config.mjs
 tsconfig.json
+
+# build artifacts
+storybook-static/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,3 +27,31 @@ jobs:
 
     - name: Run Prettier
       run: npm run check
+
+  storybook-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.9.0'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Playwright (Chromium)
+      run: npx playwright install --with-deps chromium
+
+    - name: Build Storybook
+      run: npm run build-storybook -- --quiet
+
+    - name: Serve Storybook and run test-runner
+      run: |
+        npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
+          "npx http-server storybook-static --port 6006 --silent" \
+          "npx wait-on tcp:127.0.0.1:6006 && npx test-storybook --ci"

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ next-env.d.ts
 
 # storybook
 *storybook.log
+/storybook-static/
 
 # Jujutsu: 追跡させたくない一時ファイルはここに置く
 .tmp/

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,5 +21,14 @@ const config: StorybookConfig = {
     experimentalRSC: true,
   },
   staticDirs: ['../public'],
+  // ストーリーが参照するAPI URLのデフォルト値。MSWのモック先なので実在しないダミーでよい。
+  // これにより.env(.local)が無い環境（CI等）でもストーリーが動く。
+  // 末尾の...envにより、Storybookが収集した実際の環境変数があればそちらが優先される。
+  env: (env) => ({
+    NEXT_PUBLIC_RAILS_API_URL: 'http://localhost:3001/api',
+    NEXT_PUBLIC_NEXT_URL: 'http://localhost:3000',
+    STORYBOOK_NEXT_PUBLIC_RAILS_API_URL: 'http://localhost:3001/api',
+    ...env,
+  }),
 };
 export default config;

--- a/src/stories/pageContent/MemoPageContent.stories.tsx
+++ b/src/stories/pageContent/MemoPageContent.stories.tsx
@@ -3,13 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { userEvent, within, expect, waitFor, screen } from '@storybook/test';
 import MemoPageContent from '@/components/pageContent/MemoPageContent';
 import { SessionProvider } from 'next-auth/react';
-import * as nextNavigation from 'next/navigation';
 import { createMockSession } from '@/stories/utils/mockSession';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(nextNavigation as any).useParams = () => ({
-  bookId: '1',
-});
 
 const mockSession = createMockSession({
   id: '1',
@@ -66,6 +60,9 @@ const meta: Meta<typeof MemoPageContent> = {
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,
+      navigation: {
+        segments: [['bookId', '1']],
+      },
     },
   },
 };


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/237

## description
Storybookのtest-runnerをCIに追加し、全StoryのplayテストをPRごとに自動実行する。
PF作成時はtest-runnerが不安定で外していたが、現在は安定して通るため導入する。